### PR TITLE
Add support for multiple component/module/config-provides per-package

### DIFF
--- a/doc/book/index.html
+++ b/doc/book/index.html
@@ -41,6 +41,21 @@
       </code></pre>
 
       <p>
+        You may also specify multiple components as an array:
+      </p>
+
+      <pre><code class="lang-json" data-trim>
+"extra": {
+  "zf": {
+    "component": [
+      "Some\\Component",
+      "Other\\Component"
+    ]
+  }
+}
+      </code></pre>
+
+      <p>
         Your application will need to have one or more of the following
         configuration files, from which you will be prompted to choose which one
         in which to inject the component:
@@ -78,6 +93,21 @@
 "extra": {
   "zf": {
     "module": "Some\\Component"
+  }
+}
+      </code></pre>
+
+      <p>
+        You may also specify multiple modules as an array:
+      </p>
+
+      <pre><code class="lang-json" data-trim>
+"extra": {
+  "zf": {
+    "module": [
+      "Some\\Component",
+      "Other\\Component"
+    ]
   }
 }
       </code></pre>
@@ -141,6 +171,21 @@ class ConfigProvider
       </code></pre>
 
       <p>
+        You may also specify multiple configuration providers as an array:
+      </p>
+
+      <pre><code class="lang-json" data-trim>
+"extra": {
+  "zf": {
+    "config-provider": [
+      "Some\\Component\\ConfigProvider",
+      "Some\\Component\\PluginConfigProvider",
+    ]
+  }
+}
+      </code></pre>
+
+      <p>
         Your application will need to define a <code>config/config.php</code>
         file, and that file will need to have a line that instantiates a
         <code>Zend\Expressive\ConfigManager\ConfigManager</code> instance.
@@ -196,6 +241,37 @@ class ConfigProvider
             this package to your application, whenever you add a component or module
             that exposes itself as such, the plugin will prompt you, asking where
             you want to inject it.
+          </p>
+        </div>
+      </div>
+
+      <div class="panel panel-info">
+        <div class="panel-heading">
+          <h2 class="panel-title">When are multiple items required?</h2>
+        </div>
+
+        <div class="panel-body">
+          <p>
+            As noted under each of the component, module, and config-provider
+            sections, you can optionally specify an <em>array</em> of items. When
+            would you do this?
+          </p>
+
+          <p>
+            The primary reason is for <a href="https://getcomposer.org/doc/04-schema.md#type">metapackages</a>.
+            Composer does not trigger either <code>post-package-install</code>
+            or <code>post-package-uninstall</code> events for packages defined
+            as metapackage requirements. As such, you would define the metadata
+            for such packages in the metapackage as well, to ensure that the
+            component installer can update the configuration accordingly.
+          </p>
+
+          <p>
+            The other use case is to allow specifying multiple configuration
+            providers from the same package. As an example, you might define
+            default configuration, plus configuration for plugins; specifying
+            these as separate configuration providers allows the consumer to
+            choose if they want both enabled in their application.
           </p>
         </div>
       </div>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -8,6 +8,7 @@
 namespace Zend\ComponentInstaller;
 
 use ArrayAccess;
+use ArrayIterator;
 use Countable;
 use InvalidArgumentException;
 use IteratorAggregate;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\ComponentInstaller;
+
+use ArrayAccess;
+use Countable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use OutOfRangeException;
+use Traversable;
+
+class Collection implements
+    ArrayAccess,
+    Countable,
+    IteratorAggregate
+{
+    /**
+     * @param array
+     */
+    protected $items;
+
+    /**
+     * @param array|Traversable $items
+     * @throws InvalidArgumentException
+     */
+    public function __construct($items)
+    {
+        if ($items instanceof Traversable) {
+            $items = iterator_to_array($items);
+        }
+
+        if (! is_array($items)) {
+            throw new InvalidArgumentException('Collections require arrays or Traversable objects');
+        }
+
+        $this->items = $items;
+    }
+
+    /**
+     * Factory method
+     *
+     * @param array|Traversable
+     * @return static
+     */
+    public static function create($items)
+    {
+        return new static($items);
+    }
+
+    /**
+     * Cast collection to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->items;
+    }
+
+    /**
+     * Apply a callback to each item in the collection.
+     *
+     * @param callable $callback
+     * @return self
+     */
+    public function each(callable $callback)
+    {
+        foreach ($this->items as $key => $item) {
+            $callback($item, $key);
+        }
+        return $this;
+    }
+
+    /**
+     * Reduce the collection to a single value.
+     *
+     * @param callable $callback
+     * @param mixed $initial Initial value.
+     * @return mixed
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        $accumulator = $initial;
+
+        foreach ($this->items as $key => $item) {
+            $accumulator = $callback($accumulator, $item, $key);
+        }
+
+        return $accumulator;
+    }
+
+    /**
+     * Filter the collection using a callback.
+     *
+     * Filter callback should return true for values to keep.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function filter(callable $callback)
+    {
+        return $this->reduce(function ($filtered, $item, $key) use ($callback) {
+            if ($callback($item, $key)) {
+                $filtered[$key] = $item;
+            }
+            return $filtered;
+        }, new static([]));
+    }
+
+    /**
+     * Filter the collection using a callback; reject any items matching the callback.
+     *
+     * Filter callback should return true for values to reject.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function reject(callable $callback)
+    {
+        return $this->reduce(function ($filtered, $item, $key) use ($callback) {
+            if (! $callback($item, $key)) {
+                $filtered[$key] = $item;
+            }
+            return $filtered;
+        }, new static([]));
+    }
+
+    /**
+     * Transform each value in the collection.
+     *
+     * Callback should return the new value to use.
+     *
+     * @param callable $callback
+     * @return static
+     */
+    public function map(callable $callback)
+    {
+        return $this->reduce(function ($results, $item, $key) use ($callback) {
+            $results[$key] = $callback($item, $key);
+            return $results;
+        }, new static([]));
+    }
+
+    /**
+     * Return a new collection containing only unique items.
+     *
+     * @return static
+     */
+    public function unique()
+    {
+        return new static(array_unique($this->items));
+    }
+
+    /**
+     * Merge an array of values with the current collection.
+     *
+     * @return self
+     */
+    public function merge(array $values)
+    {
+        $this->items = array_merge($this->items, $values);
+        return $this;
+    }
+
+    /**
+     * Prepend a value to the collection.
+     *
+     * @return self
+     */
+    public function prepend($value)
+    {
+        array_unshift($this->items, $value);
+        return $this;
+    }
+
+    /**
+     * ArrayAccess: isset()
+     *
+     * @param string|int $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->items);
+    }
+
+    /**
+     * ArrayAccess: retrieve by key
+     *
+     * @param string|int $offset
+     * @return mixed
+     */
+    public function offsetGet($offset)
+    {
+        if (! $this->offsetExists($offset)) {
+            throw new OutOfRangeException(sprintf(
+                'Offset %s does not exist in the collection',
+                $offset
+            ));
+        }
+
+        return $this->items[$offset];
+    }
+
+    /**
+     * ArrayAccess: set by key
+     *
+     * If $offset is null, pushes the item onto the stack.
+     *
+     * @param string|int $offset
+     * @param mixed $value
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (null === $offset) {
+            $this->items[] = $value;
+            return;
+        }
+
+        $this->items[$offset] = $value;
+    }
+
+    /**
+     * ArrayAccess: unset()
+     *
+     * @param string|int $offset
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        if ($this->offsetExists($offset)) {
+            unset($this->items[$offset]);
+        }
+    }
+
+    /**
+     * Countable: number of items in the collection.
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    /**
+     * Is the collection empty?
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return 0 === $this->count();
+    }
+
+    /**
+     * Traversable: Iterate the collection.
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->items);
+    }
+}

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -35,53 +35,48 @@ class ConfigDiscovery
     /**
      * Return a list of available configuration options.
      *
-     * @param array $availableTypes List of Injector\InjectorInterface::TYPE_*
+     * @param Collection $availableTypes Collection of Injector\InjectorInterface::TYPE_*
      *     constants indicating valid package types that could be injected.
      * @param string $projectRoot Path to the project root; assumes PWD by
      *     default.
      * @return ConfigOption[]
      */
-    public function getAvailableConfigOptions(array $availableTypes, $projectRoot = '')
+    public function getAvailableConfigOptions(Collection $availableTypes, $projectRoot = '')
     {
-        $discovered = [
+        // Create an initial collection to which we'll append.
+        // This approach is used to ensure indexes are sane.
+        $discovered = new Collection([
             new ConfigOption('Do not inject', new Injector\NoopInjector()),
-        ];
+        ]);
 
-        foreach ($this->discovery as $file => $discoveryClass) {
-            $discovery = new $discoveryClass($projectRoot);
-            if (! $discovery->locate()) {
-                continue;
-            }
+        Collection::create($this->discovery)
+            // Create a discovery class for the dicovery type
+            ->map(function ($discoveryClass) use ($projectRoot) {
+                return new $discoveryClass($projectRoot);
+            })
+            // Use only those where we can locate a corresponding config file
+            ->filter(function ($discovery) {
+                return $discovery->locate();
+            })
+            // Create an injector for the config file
+            ->map(function ($discovery, $file) use ($projectRoot) {
+                // Look up the injector based on the file type
+                $injectorClass = $this->injectors[$file];
+                return new $injectorClass($projectRoot);
+            })
+            // Keep only those injectors that match types available for the package
+            ->filter(function ($injector) use ($availableTypes) {
+                return $availableTypes->reduce(function ($flag, $type) use ($injector) {
+                    return $flag || $injector->registersType($type);
+                }, false);
+            })
+            // Create a config option using the file and injector
+            ->each(function ($injector, $file) use ($discovered) {
+                $discovered[] = new ConfigOption($file, $injector);
+            });
 
-            $injectorClass = $this->injectors[$file];
-            $injector = new $injectorClass($projectRoot);
-
-            if (! $this->injectorCanRegisterAvailableType($injector, $availableTypes)) {
-                continue;
-            }
-
-            $discovered[] = new ConfigOption($file, $injector);
-        }
-
-        return (count($discovered) === 1)
-            ? []
+        return (1 === $discovered->count())
+            ? new Collection([])
             : $discovered;
-    }
-
-    /**
-     * Determine if the given injector can handle any of the types exposed by the package.
-     *
-     * @param Injector\InjectorInterface $injector
-     * @param int[] $availableTypes
-     * @return bool
-     */
-    private function injectorCanRegisterAvailableType(Injector\InjectorInterface $injector, array $availableTypes)
-    {
-        foreach ($availableTypes as $type) {
-            if ($injector->registersType($type)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -39,7 +39,7 @@ class ConfigDiscovery
      *     constants indicating valid package types that could be injected.
      * @param string $projectRoot Path to the project root; assumes PWD by
      *     default.
-     * @return ConfigOption[]
+     * @return Collection Collection of ConfigOption instances.
      */
     public function getAvailableConfigOptions(Collection $availableTypes, $projectRoot = '')
     {

--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -164,11 +164,11 @@ abstract class AbstractInjector implements InjectorInterface
     /**
      * Remove a package from the configuration.
      *
-     * @var string $package Package name.
-     * @var string $config
+     * @param string $package Package name.
+     * @param IOInterface $io
      * @return void
      */
-    public function remove($package, $type, IOInterface $io)
+    public function remove($package, IOInterface $io)
     {
         $config = file_get_contents($this->configFile);
 
@@ -202,6 +202,6 @@ abstract class AbstractInjector implements InjectorInterface
      */
     protected function isRegisteredInConfig($package, $config)
     {
-        return (1 === preg_match(sprintf($this->isRegisteredPattern, preg_quote($package)), $config));
+        return (1 === preg_match(sprintf($this->isRegisteredPattern, preg_quote($package, '/')), $config));
     }
 }

--- a/src/Injector/ExpressiveConfigInjector.php
+++ b/src/Injector/ExpressiveConfigInjector.php
@@ -97,8 +97,8 @@ class ExpressiveConfigInjector extends AbstractInjector
      * Prepends the package with a `\\` in order to ensure it is fully
      * qualified, preventing issues in config files that are namespaced.
      */
-    public function remove($package, $type, IOInterface $io)
+    public function remove($package, IOInterface $io)
     {
-        parent::remove('\\' . $package, $type, $io);
+        parent::remove('\\' . $package, $io);
     }
 }

--- a/src/Injector/InjectorInterface.php
+++ b/src/Injector/InjectorInterface.php
@@ -51,9 +51,8 @@ interface InjectorInterface
      * Remove a package from the configuration.
      *
      * @param string $package Package to remove.
-     * @param int $type One of the TYPE_* constants
      * @param IOInterface $io
      * @return void
      */
-    public function remove($package, $type, IOInterface $io);
+    public function remove($package, IOInterface $io);
 }

--- a/src/Injector/NoopInjector.php
+++ b/src/Injector/NoopInjector.php
@@ -25,11 +25,7 @@ class NoopInjector implements InjectorInterface
      */
     public function getTypesAllowed()
     {
-        return [
-            self::TYPE_CONFIG_PROVIDER,
-            self::TYPE_COMPONENT,
-            self::TYPE_MODULE,
-        ];
+        return [];
     }
 
     /**
@@ -51,7 +47,7 @@ class NoopInjector implements InjectorInterface
     /**
      * {@inheritDoc}
      */
-    public function remove($package, $type, IOInterface $io)
+    public function remove($package, IOInterface $io)
     {
     }
 }

--- a/test/Injector/AbstractInjectorTestCase.php
+++ b/test/Injector/AbstractInjectorTestCase.php
@@ -103,7 +103,7 @@ abstract class AbstractInjectorTestCase extends TestCase
         $io = $this->prophesize(IOInterface::class);
         $io->write(Argument::type('string'))->shouldNotBeCalled();
 
-        $this->assertNull($this->injector->remove('Foo\Bar', $type, $io->reveal()));
+        $this->assertNull($this->injector->remove('Foo\Bar', $io->reveal()));
     }
 
     abstract public function packagePopulatedInConfiguration();
@@ -124,7 +124,7 @@ abstract class AbstractInjectorTestCase extends TestCase
             return preg_match($pattern, $message);
         }))->shouldBeCalled();
 
-        $this->injector->remove('Foo\Bar', $type, $io->reveal());
+        $this->injector->remove('Foo\Bar', $io->reveal());
 
         $result = file_get_contents(vfsStream::url('project/' . $this->configFile));
         $this->assertSame($expectedContents, $result);

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -18,34 +18,25 @@ class NoopInjectorTest extends TestCase
         $this->injector = new NoopInjector();
     }
 
-    public function testWillRegisterAnyType()
+    /**
+     * @dataProvider packageTypes
+     */
+    public function testWillRegisterAnyType($type)
     {
-        $types = [
-            NoopInjector::TYPE_CONFIG_PROVIDER,
-            NoopInjector::TYPE_COMPONENT,
-            NoopInjector::TYPE_MODULE,
-        ];
-        foreach ($types as $type) {
-            $this->assertTrue($this->injector->registersType($type), 'NoopInjector does not register type ' . $type);
-        }
+        $this->assertTrue($this->injector->registersType($type), 'NoopInjector does not register type ' . $type);
     }
 
-    public function testGetTypesAllowedReturnsAllTypes()
+    public function testGetTypesAllowedReturnsNoTypes()
     {
-        $types = [
-            NoopInjector::TYPE_CONFIG_PROVIDER,
-            NoopInjector::TYPE_COMPONENT,
-            NoopInjector::TYPE_MODULE,
-        ];
-        $this->assertEquals($types, $this->injector->getTypesAllowed());
+        $this->assertEquals([], $this->injector->getTypesAllowed());
     }
 
     public function packageTypes()
     {
         return [
             'config-provider' => [NoopInjector::TYPE_CONFIG_PROVIDER],
-            'component' => [NoopInjector::TYPE_COMPONENT],
-            'module' => [NoopInjector::TYPE_MODULE],
+            'component'       => [NoopInjector::TYPE_COMPONENT],
+            'module'          => [NoopInjector::TYPE_MODULE],
         ];
     }
 
@@ -66,6 +57,6 @@ class NoopInjectorTest extends TestCase
     {
         $io = $this->prophesize(IOInterface::class);
         $io->write(Argument::any())->shouldNotBeCalled();
-        $this->assertNull($this->injector->remove('Foo\Bar', $type, $io->reveal()));
+        $this->assertNull($this->injector->remove('Foo\Bar', $io->reveal()));
     }
 }


### PR DESCRIPTION
In playing with composer metapackages, I discovered that `post-package-install` and `post-package-uninstall` subscribers are not triggered for the packages required by the metapackage.

To get around this limitation, my proposed solution is to allow each of `extra.zf.component`, `extra.zf.module`, and `extra.zf.config-provider` to allow not only strings, but arrays of strings:

``` json
{
    "extra": {
        "zf": {
            "component": [
                "Zend\\Mvc\\Plugin\\FilePrg",
                "Zend\\Mvc\\Plugin\\FlashMessenger",
                "Zend\\Mvc\\Plugin\\Identity",
                "Zend\\Mvc\\Plugin\\Prg",
            ]
        }
    }
}
```

To enable this required a fair amount of refactoring, primarily to reduce the complexity of nested `foreach` loops. As such, this patch introduces a new `Collection` class that provides options for filtering, rejecting, merging, reducing, mapping, and retrieving unique values, simplifying a fair bit of code internally. Interestingly, very few test expectations needed to change, and new tests were introduced demonstrating the new behavior for the multiples support.
