### PR TITLE
Fix detection and injection of development configuration

### DIFF
--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -16,7 +16,7 @@ class ConfigDiscovery
     private $discovery = [
         'config/application.config.php' => ConfigDiscovery\ApplicationConfig::class,
         'config/modules.config.php' => ConfigDiscovery\ModulesConfig::class,
-        'config/development.config.php' => ConfigDiscovery\DevelopmentConfig::class,
+        'config/development.config.php.dist' => ConfigDiscovery\DevelopmentConfig::class,
         'config/config.php' => ConfigDiscovery\ExpressiveConfig::class,
     ];
 
@@ -28,7 +28,7 @@ class ConfigDiscovery
     private $injectors = [
         'config/application.config.php' => Injector\ApplicationConfigInjector::class,
         'config/modules.config.php' => Injector\ModulesConfigInjector::class,
-        'config/development.config.php' => Injector\DevelopmentConfigInjector::class,
+        'config/development.config.php.dist' => Injector\DevelopmentConfigInjector::class,
         'config/config.php' => Injector\ExpressiveConfigInjector::class,
     ];
 

--- a/src/ConfigDiscovery/DevelopmentConfig.php
+++ b/src/ConfigDiscovery/DevelopmentConfig.php
@@ -13,5 +13,5 @@ class DevelopmentConfig extends ApplicationConfig
      *
      * @var string
      */
-    protected $configFile = 'config/development.config.php';
+    protected $configFile = 'config/development.config.php.dist';
 }

--- a/src/Injector/DevelopmentConfigInjector.php
+++ b/src/Injector/DevelopmentConfigInjector.php
@@ -13,5 +13,5 @@ class DevelopmentConfigInjector extends ApplicationConfigInjector
      *
      * @var string
      */
-    protected $configFile = 'config/development.config.php';
+    protected $configFile = 'config/development.config.php.dist';
 }

--- a/test/ConfigDiscovery/DevelopmentConfigTest.php
+++ b/test/ConfigDiscovery/DevelopmentConfigTest.php
@@ -32,7 +32,7 @@ class DevelopmentConfigTest extends TestCase
 
     public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
     {
-        vfsStream::newFile('config/development.config.php')
+        vfsStream::newFile('config/development.config.php.dist')
             ->at($this->configDir)
             ->setContent('<' . "?php\nreturn [];");
         $this->assertFalse($this->locator->locate());
@@ -51,7 +51,7 @@ class DevelopmentConfigTest extends TestCase
      */
     public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
     {
-        vfsStream::newFile('config/development.config.php')
+        vfsStream::newFile('config/development.config.php.dist')
             ->at($this->configDir)
             ->setContent($contents);
 

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -51,7 +51,7 @@ class ConfigDiscoveryTest extends TestCase
 
     public function createDevelopmentConfig()
     {
-        vfsStream::newFile('config/development.config.php')
+        vfsStream::newFile('config/development.config.php.dist')
             ->at($this->projectRoot)
             ->setContent('<' . "?php\nreturn [\n    'modules' => [\n    ]\n];");
     }

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -10,7 +10,7 @@ use Zend\ComponentInstaller\Injector\DevelopmentConfigInjector;
 
 class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
 {
-    protected $configFile = 'config/development.config.php';
+    protected $configFile = 'config/development.config.php.dist';
 
     protected $injectorClass = DevelopmentConfigInjector::class;
 


### PR DESCRIPTION
zf-development-mode uses `development.config.php.dist` as the base development configuration, and copies that to `development.config.php`, which is _excluded_ from the repository. As such, we need to write to the former, not the latter.
