### PR TITLE
Ensure modules are injected last

### DIFF
--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -169,7 +169,6 @@ class ComponentInstaller implements
             return;
         }
 
-
         $packageTypes = $this->discoverPackageTypes($extra);
         $options = (new ConfigDiscovery())
             ->getAvailableConfigOptions($packageTypes, $this->projectRoot);
@@ -188,8 +187,8 @@ class ComponentInstaller implements
                 return $injectors;
             }, new Collection([]))
             // Inject modules into configuration
-            ->each(function ($injector, $module) use ($name) {
-                $this->injectModuleIntoConfig($name, $module, $injector);
+            ->each(function ($injector, $module) use ($name, $packageTypes) {
+                $this->injectModuleIntoConfig($name, $module, $injector, $packageTypes);
             });
     }
 
@@ -407,12 +406,13 @@ class ComponentInstaller implements
      * @param string $package Package name
      * @param string $module Module to install in configuration
      * @param Injector\InjectorInterface $injector Injector to use.
+     * @param Collection $packageTypes
      * @return void
      */
-    private function injectModuleIntoConfig($package, $module, Injector\InjectorInterface $injector)
+    private function injectModuleIntoConfig($package, $module, Injector\InjectorInterface $injector, Collection $packageTypes)
     {
         // Find the first package type the injector can handle.
-        $type = Collection::create(array_keys($this->packageTypes))
+        $type = $packageTypes
             ->reduce(function ($discovered, $type) use ($injector) {
                 if ($discovered) {
                     return $discovered;

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -409,8 +409,12 @@ class ComponentInstaller implements
      * @param Collection $packageTypes
      * @return void
      */
-    private function injectModuleIntoConfig($package, $module, Injector\InjectorInterface $injector, Collection $packageTypes)
-    {
+    private function injectModuleIntoConfig(
+        $package,
+        $module,
+        Injector\InjectorInterface $injector,
+        Collection $packageTypes
+    ) {
         // Find the first package type the injector can handle.
         $type = $packageTypes
             ->reduce(function ($discovered, $type) use ($injector) {

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -468,7 +468,6 @@ class ComponentInstallerTest extends TestCase
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
-
         $this->assertContains("'Other\Component'", $config);
     }
 

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -629,7 +629,9 @@ class ComponentInstallerTest extends TestCase
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
         $config = include(vfsStream::url('project/config/application.config.php'));
         $modules = $config['modules'];
-        end($modules);
-        $this->assertEquals('Some\Module', current($modules));
+        $this->assertEquals([
+            'Some\Component',
+            'Some\Module'
+        ], $modules);
     }
 }

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -468,6 +468,7 @@ class ComponentInstallerTest extends TestCase
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
+
         $this->assertContains("'Other\Component'", $config);
     }
 
@@ -570,5 +571,66 @@ class ComponentInstallerTest extends TestCase
         $config = file_get_contents(vfsStream::url('project/config/application.config.php'));
         $this->assertNotContains('Some\Component', $config);
         $this->assertNotContains('Other\Component', $config);
+    }
+
+    public function testModuleIsAppended()
+    {
+        $this->createApplicationConfig(
+            '<' . "?php\nreturn [\n    'modules' => [\n        'Some\Component',\n    ]\n];"
+        );
+
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/module');
+        $package->getExtra()->willReturn(['zf' => [
+            'module' => 'Some\\Module',
+        ]]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+
+            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Module' into")) {
+                return false;
+            }
+
+            if (! strstr($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (! strstr($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+            if (! strstr($argument[0], 'Remember')) {
+                return false;
+            }
+
+            return true;
+        }), 'n')->willReturn('n');
+
+        $this->io->write(Argument::that(function ($argument) {
+            return strstr($argument, 'Installing Some\Module from package some/module');
+        }))->shouldBeCalled();
+
+        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $config = include(vfsStream::url('project/config/application.config.php'));
+        $modules = $config['modules'];
+        end($modules);
+        $this->assertEquals('Some\Module', current($modules));
     }
 }


### PR DESCRIPTION
This patch builds on the one submitted in #9 in order to solve #7, providing the code changes necessary in the installer to ensure that the configured component type (compontent vs module) is used when injecting the component/module into configuration. Essentially, the change only requires passing the collection of discovered package types to `injectModuleIntoConfig()` and reducing that collection.
