### PR TITLE
"Component" and "Module" in one package HOTFIX

### DIFF
--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -634,4 +634,182 @@ class ComponentInstallerTest extends TestCase
             'Some\Module'
         ], $modules);
     }
+
+    public function testAppendModuleAndPrependComponent()
+    {
+        $this->createApplicationConfig(
+            '<' . "?php\nreturn [\n    'modules' => [\n        'SomeApplication',\n    ]\n];"
+        );
+
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/package');
+        $package->getExtra()->willReturn(['zf' => [
+            'module' => 'Some\\Module',
+            'component' => 'Some\\Component',
+        ]]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+
+            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Module' into")) {
+                return false;
+            }
+
+            if (! strstr($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (! strstr($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+
+            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
+                return false;
+            }
+
+            if (! strstr($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (! strstr($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+            if (! strstr($argument[0], 'Remember')) {
+                return false;
+            }
+
+            return true;
+        }), 'n')->willReturn('n');
+
+        $this->io->write(Argument::that(function ($argument) {
+            return strstr($argument, 'Installing Some\Module from package some/package');
+        }))->shouldBeCalled();
+
+        $this->io->write(Argument::that(function ($argument) {
+            return strstr($argument, 'Installing Some\Component from package some/package');
+        }))->shouldBeCalled();
+
+        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $config = include(vfsStream::url('project/config/application.config.php'));
+        $modules = $config['modules'];
+        $this->assertEquals([
+            'Some\Component',
+            'SomeApplication',
+            'Some\Module',
+        ], $modules);
+    }
+
+    public function testPrependComponentAndAppendModule()
+    {
+        $this->createApplicationConfig(
+            '<' . "?php\nreturn [\n    'modules' => [\n        'SomeApplication',\n    ]\n];"
+        );
+
+        $package = $this->prophesize(PackageInterface::class);
+        $package->getName()->willReturn('some/package');
+        $package->getExtra()->willReturn(['zf' => [
+            'component' => 'Some\\Component',
+            'module' => 'Some\\Module',
+        ]]);
+
+        $operation = $this->prophesize(InstallOperation::class);
+        $operation->getPackage()->willReturn($package->reveal());
+
+        $event = $this->prophesize(PackageEvent::class);
+        $event->isDevMode()->willReturn(true);
+        $event->getOperation()->willReturn($operation->reveal());
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+
+            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Module' into")) {
+                return false;
+            }
+
+            if (! strstr($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (! strstr($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+
+            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
+                return false;
+            }
+
+            if (! strstr($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (! strstr($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+            if (! strstr($argument[0], 'Remember')) {
+                return false;
+            }
+
+            return true;
+        }), 'n')->willReturn('n');
+
+        $this->io->write(Argument::that(function ($argument) {
+            return strstr($argument, 'Installing Some\Module from package some/package');
+        }))->shouldBeCalled();
+
+        $this->io->write(Argument::that(function ($argument) {
+            return strstr($argument, 'Installing Some\Component from package some/package');
+        }))->shouldBeCalled();
+
+        $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
+        $config = include(vfsStream::url('project/config/application.config.php'));
+        $modules = $config['modules'];
+        $this->assertEquals([
+            'Some\Component',
+            'SomeApplication',
+            'Some\Module',
+        ], $modules);
+    }
 }


### PR DESCRIPTION
If we have package which have `component` and `module` defined in `extra.zf` then both are prepended or appended on the module list. Please have a look on these tests.

Please notice that only ONE difference in these two tests is:

``` php
        $package->getExtra()->willReturn(['zf' => [
            'module' => 'Some\\Module',
            'component' => 'Some\\Component',
        ]]);
```

and:

``` php
        $package->getExtra()->willReturn(['zf' => [
            'component' => 'Some\\Component',
            'module' => 'Some\\Module',
        ]]);
```

It shouldn't matter what order of modules/components we have in `extra.zf` and the result should be always the same: modules should be appended and components prepended, so:

```
        'Some\Component',
        'SomeApplication',
        'Some\Module',
```

As we can see test `testAppendModuleAndPrependComponent` now failing because current result is:

```
        'SomeApplication'
        'Some\Component'
        'Some\Module'
```

(both appended).

and test `testPrependComponentAndAppendModule` is failing because current result is:

```
        'Some\Module'
        'Some\Component'
        'SomeApplication'
```

(both prepended).
