### PR TITLE
Features - module dependencies and inject before application

### DIFF
--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -14,6 +14,7 @@ use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\Event as CommandEvent;
 use Composer\Script\PackageEvent;
+use DirectoryIterator;
 
 /**
  * If a package represents a component module, update the application configuration.
@@ -260,7 +261,7 @@ class ComponentInstaller implements
         $modules = [];
 
         if (is_dir($modulePath)) {
-            $directoryIterator = new \DirectoryIterator($modulePath);
+            $directoryIterator = new DirectoryIterator($modulePath);
             foreach ($directoryIterator as $file) {
                 if ($file->isDot() || ! $file->isDir()) {
                     continue;

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -8,11 +8,9 @@ namespace Zend\ComponentInstaller;
 
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
-use Composer\Installer\InstallerEvent;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\Script\Event as CommandEvent;
 use Composer\Script\PackageEvent;
 use DirectoryIterator;
 

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -205,7 +205,7 @@ class ComponentInstaller implements
      * - to get package dependencies - module method `getModuleDependencies`
      * and add component in a correct order on the module list.
      *
-     * It works currently with PSR-0 and PSR-4 autoloaded packages.
+     * It works with PSR-0, PSR-4, 'classmap' and 'files' composer autoloading.
      *
      * @param PackageInterface $package
      * @return void
@@ -219,6 +219,22 @@ class ComponentInstaller implements
         foreach ($autoload as $type => $map) {
             foreach ($map as $namespace => $path) {
                 switch ($type) {
+                    case 'classmap':
+                        $fullPath = sprintf('%s/%s', $packagePath, $path);
+                        if (is_dir(rtrim($fullPath, '/'))) {
+                            $modulePath = sprintf('%s%s', $fullPath, 'Module.php');
+                        } elseif (substr($path, -10) == 'Module.php') {
+                            $modulePath = $fullPath;
+                        } else {
+                            continue 2;
+                        }
+                        break;
+                    case 'files':
+                        if (substr($path, -10) != 'Module.php') {
+                            continue 2;
+                        }
+                        $modulePath = sprintf('%s/%s', $packagePath, $path);
+                        break;
                     case 'psr-0':
                         $modulePath = sprintf(
                             '%s/%s%s%s',

--- a/src/Injector/ApplicationConfigInjector.php
+++ b/src/Injector/ApplicationConfigInjector.php
@@ -33,6 +33,10 @@ class ApplicationConfigInjector extends AbstractInjector
             'pattern' => '/^(\s+)(\'modules\'\s*\=\>\s*(?:array\s*\(|\[)[^)\]]*\'%s\')/m',
             'replacement' => "\$1\$2,\n\$1    '%s'",
         ],
+        self::TYPE_BEFORE_APPLICATION => [
+            'pattern' => '/^(\s+)(\'modules\'\s*\=\>\s*(?:array\s*\(|\[)[^)\]]*)(\'%s\')/m',
+            'replacement' => "\$1\$2'%s',\n$1    \$3",
+        ],
     ];
 
     /**

--- a/src/Injector/ApplicationConfigInjector.php
+++ b/src/Injector/ApplicationConfigInjector.php
@@ -29,6 +29,10 @@ class ApplicationConfigInjector extends AbstractInjector
             'pattern' => "/('modules'\s*\=\>\s*(?:array\s*\(|\[).*?)\n(\s+)(\)|\])/s",
             'replacement' => "\$1\n\$2    '%s',\n\$2\$3",
         ],
+        self::TYPE_DEPENDENCY => [
+            'pattern' => '/^(\s+)(\'modules\'\s*\=\>\s*(?:array\s*\(|\[)[^)\]]*\'%s\')/m',
+            'replacement' => "\$1\$2,\n\$1    '%s'",
+        ],
     ];
 
     /**

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -129,4 +129,12 @@ class ConfigInjectorChain implements InjectorInterface
     {
         return $this->chain;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setApplicationModules(array $modules)
+    {
+        return $this;
+    }
 }

--- a/src/Injector/InjectorInterface.php
+++ b/src/Injector/InjectorInterface.php
@@ -13,6 +13,7 @@ interface InjectorInterface
     const TYPE_CONFIG_PROVIDER = 0;
     const TYPE_COMPONENT = 1;
     const TYPE_MODULE = 2;
+    const TYPE_DEPENDENCY = 3;
 
     /**
      * Whether or not the injector can handle the given type.

--- a/src/Injector/InjectorInterface.php
+++ b/src/Injector/InjectorInterface.php
@@ -14,6 +14,7 @@ interface InjectorInterface
     const TYPE_COMPONENT = 1;
     const TYPE_MODULE = 2;
     const TYPE_DEPENDENCY = 3;
+    const TYPE_BEFORE_APPLICATION = 4;
 
     /**
      * Whether or not the injector can handle the given type.
@@ -56,4 +57,12 @@ interface InjectorInterface
      * @return void
      */
     public function remove($package, IOInterface $io);
+
+    /**
+     * Set modules of the application.
+     *
+     * @param array $modules
+     * @return self
+     */
+    public function setApplicationModules(array $modules);
 }

--- a/src/Injector/ModulesConfigInjector.php
+++ b/src/Injector/ModulesConfigInjector.php
@@ -29,6 +29,10 @@ class ModulesConfigInjector extends AbstractInjector
             'pattern' => "/(return\s+(?:array\s*\(|\[).*?)\n(\s*)(\)|\])/s",
             'replacement' => "\$1\n\$2    '%s',\n\$2\$3",
         ],
+        self::TYPE_DEPENDENCY => [
+            'pattern' => '/^(return\s+(?:array\s*\(|\[)[^)\]]*\'%s\')/m',
+            'replacement' => "\$1,\n    '%s'",
+        ],
     ];
 
     /**

--- a/src/Injector/ModulesConfigInjector.php
+++ b/src/Injector/ModulesConfigInjector.php
@@ -33,6 +33,10 @@ class ModulesConfigInjector extends AbstractInjector
             'pattern' => '/^(return\s+(?:array\s*\(|\[)[^)\]]*\'%s\')/m',
             'replacement' => "\$1,\n    '%s'",
         ],
+        self::TYPE_BEFORE_APPLICATION => [
+            'pattern' => '/^(return\s+(?:array\s*\(|\[)[^)\]]*)(\'%s\')/m',
+            'replacement' => "\$1'%s',\n    \$2",
+        ],
     ];
 
     /**

--- a/src/Injector/NoopInjector.php
+++ b/src/Injector/NoopInjector.php
@@ -50,4 +50,12 @@ class NoopInjector implements InjectorInterface
     public function remove($package, IOInterface $io)
     {
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setApplicationModules(array $modules)
+    {
+        return $this;
+    }
 }

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -17,6 +17,7 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
     protected $injectorTypesAllowed = [
         ApplicationConfigInjector::TYPE_COMPONENT,
         ApplicationConfigInjector::TYPE_MODULE,
+        ApplicationConfigInjector::TYPE_DEPENDENCY,
     ];
 
     public function allowedTypes()
@@ -25,6 +26,7 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
             'config-provider' => [ApplicationConfigInjector::TYPE_CONFIG_PROVIDER, false],
             'component'       => [ApplicationConfigInjector::TYPE_COMPONENT, true],
             'module'          => [ApplicationConfigInjector::TYPE_MODULE, true],
+            'dependency'      => [ApplicationConfigInjector::TYPE_DEPENDENCY, true],
         ];
     }
 

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -18,6 +18,7 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         ApplicationConfigInjector::TYPE_COMPONENT,
         ApplicationConfigInjector::TYPE_MODULE,
         ApplicationConfigInjector::TYPE_DEPENDENCY,
+        ApplicationConfigInjector::TYPE_BEFORE_APPLICATION,
     ];
 
     public function allowedTypes()
@@ -27,6 +28,7 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
             'component'       => [ApplicationConfigInjector::TYPE_COMPONENT, true],
             'module'          => [ApplicationConfigInjector::TYPE_MODULE, true],
             'dependency'      => [ApplicationConfigInjector::TYPE_DEPENDENCY, true],
+            'before-application-modules' => [ApplicationConfigInjector::TYPE_BEFORE_APPLICATION, true],
         ];
     }
 

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -17,6 +17,7 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
     protected $injectorTypesAllowed = [
         DevelopmentConfigInjector::TYPE_COMPONENT,
         DevelopmentConfigInjector::TYPE_MODULE,
+        DevelopmentConfigInjector::TYPE_DEPENDENCY,
     ];
 
     public function allowedTypes()
@@ -25,6 +26,7 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
             'config-provider' => [DevelopmentConfigInjector::TYPE_CONFIG_PROVIDER, false],
             'component'       => [DevelopmentConfigInjector::TYPE_COMPONENT, true],
             'module'          => [DevelopmentConfigInjector::TYPE_MODULE, true],
+            'dependency'      => [DevelopmentConfigInjector::TYPE_DEPENDENCY, true],
         ];
     }
 

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -18,6 +18,7 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         DevelopmentConfigInjector::TYPE_COMPONENT,
         DevelopmentConfigInjector::TYPE_MODULE,
         DevelopmentConfigInjector::TYPE_DEPENDENCY,
+        DevelopmentConfigInjector::TYPE_BEFORE_APPLICATION,
     ];
 
     public function allowedTypes()
@@ -27,6 +28,7 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
             'component'       => [DevelopmentConfigInjector::TYPE_COMPONENT, true],
             'module'          => [DevelopmentConfigInjector::TYPE_MODULE, true],
             'dependency'      => [DevelopmentConfigInjector::TYPE_DEPENDENCY, true],
+            'before-application-modules' => [DevelopmentConfigInjector::TYPE_BEFORE_APPLICATION, true],
         ];
     }
 

--- a/test/Injector/ModulesConfigInjectorTest.php
+++ b/test/Injector/ModulesConfigInjectorTest.php
@@ -18,6 +18,7 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         ModulesConfigInjector::TYPE_COMPONENT,
         ModulesConfigInjector::TYPE_MODULE,
         ModulesConfigInjector::TYPE_DEPENDENCY,
+        ModulesConfigInjector::TYPE_BEFORE_APPLICATION,
     ];
 
     public function allowedTypes()
@@ -27,6 +28,7 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
             'component'       => [ModulesConfigInjector::TYPE_COMPONENT, true],
             'module'          => [ModulesConfigInjector::TYPE_MODULE, true],
             'dependency'      => [ModulesConfigInjector::TYPE_DEPENDENCY, true],
+            'before-application-modules' => [ModulesConfigInjector::TYPE_BEFORE_APPLICATION, true],
         ];
     }
 

--- a/test/Injector/ModulesConfigInjectorTest.php
+++ b/test/Injector/ModulesConfigInjectorTest.php
@@ -17,6 +17,7 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
     protected $injectorTypesAllowed = [
         ModulesConfigInjector::TYPE_COMPONENT,
         ModulesConfigInjector::TYPE_MODULE,
+        ModulesConfigInjector::TYPE_DEPENDENCY,
     ];
 
     public function allowedTypes()
@@ -25,6 +26,7 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
             'config-provider' => [ModulesConfigInjector::TYPE_CONFIG_PROVIDER, false],
             'component'       => [ModulesConfigInjector::TYPE_COMPONENT, true],
             'module'          => [ModulesConfigInjector::TYPE_MODULE, true],
+            'dependency'      => [ModulesConfigInjector::TYPE_DEPENDENCY, true],
         ];
     }
 


### PR DESCRIPTION
(Unfortunately) **two** features in one PR:
## 1. Detecting module dependencies

Injecting component after dependencies. Module dependencies we get from `Module:: getModuleDependencies`.

This will be useful in case package is using `extra.zf.component` and depends on another module.
`Component` is injected always on top of the module list, but with this feature will be injected just after all dependencies, so it prevents error:

> Module "X" depends on module "Y", which was not initialized before it ...

There are few problems:
- cannot use autoloader, so try to find the path and include this file
- if Module class implements interfaces or extends another class these classes should be also loaded somehow (it is not done)
- how to load Module class if library is not using PSR-0/PSR-4 autoloading?
## 2. Detecting application modules

Injecting modules **before** enabled application modules (not at the end)
I've made an assumption that application's modules should be in `module/` directory.
Then we can detect what application's modules are enabled and inject modules before an application.
I think it's important because then we can **override** configuration in the application module. Otherwise it will be always from the module and it will be not possible to override it in `module.config.php` (only in global/local config for the whole application).

---

I don't like too much this code. I think the functionality will be useful in some cases. I've opened this PR with the hope, someone will have a look on it and help how we can improve it. I'll put some comments also in code below. Any comments/suggestions will be appreciated. Thanks!
