### PR TITLE
Alternative to #23 - module dependencies - regex instead of include

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,4 +19,5 @@
     <file>src</file>
     <file>test</file>
     <exclude-pattern>test/Injector/TestAsset/*.php</exclude-pattern>
+    <exclude-pattern>test/TestAsset/Module*.php</exclude-pattern>
 </ruleset>

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -178,7 +178,7 @@ class ComponentInstaller implements
             return;
         }
 
-        $this->includeModuleClasses($package);
+        $dependencies = $this->loadModuleClassesDependencies($package);
         $applicationModules = $this->findApplicationModules();
 
         $this->marshalInstallableModules($extra, $options)
@@ -190,26 +190,32 @@ class ComponentInstaller implements
                 return $injectors;
             }, new Collection([]))
             // Inject modules into configuration
-            ->each(function ($injector, $module) use ($name, $packageTypes, $applicationModules) {
+            ->each(function ($injector, $module) use ($name, $packageTypes, $applicationModules, $dependencies) {
+                if (isset($dependencies[$module])) {
+                    $injector->setModuleDependencies($dependencies[$module]);
+                }
+
                 $injector->setApplicationModules($applicationModules);
                 $this->injectModuleIntoConfig($name, $module, $injector, $packageTypes[$module]);
             });
     }
 
     /**
-     * Find all Module classes in the package and include them.
-     * Module classes is used later
+     * Find all Module classes in the package and their dependencies
+     * - method `getModuleDependencies` of Module class.
+     *
+     * These dependencies are used later
      * @see \Zend\ComponentInstaller\Injector\AbstractInjector::injectAfterDependencies
-     * - to get package dependencies - module method `getModuleDependencies`
-     * and add component in a correct order on the module list.
+     * to add component in a correct order on the module list - after dependencies.
      *
      * It works with PSR-0, PSR-4, 'classmap' and 'files' composer autoloading.
      *
      * @param PackageInterface $package
-     * @return void
+     * @return array
      */
-    private function includeModuleClasses(PackageInterface $package)
+    private function loadModuleClassesDependencies(PackageInterface $package)
     {
+        $dependencies = [];
         $installer = $this->composer->getInstallationManager();
         $packagePath = $installer->getInstallPath($package);
 
@@ -255,10 +261,39 @@ class ComponentInstaller implements
                 }
 
                 if (file_exists($modulePath)) {
-                    include $modulePath;
+                    if ($result = $this->getModuleDependencies($modulePath)) {
+                        $dependencies += $result;
+                    }
                 }
             }
         }
+
+        return $dependencies;
+    }
+
+    /**
+     * @param string $file
+     * @return array
+     */
+    private function getModuleDependencies($file)
+    {
+        $content = file_get_contents($file);
+        if (preg_match('/namespace\s+([^\s]+)\s*;/', $content, $m)) {
+            $moduleName = $m[1];
+
+            // @codingStandardsIgnoreStart
+            $regExp = '/public\s+function\s+getModuleDependencies\s*\(\s*\)\s*{[^}]*return\s*(?:array\(|\[)([^})\]]*)(\)|\])/';
+            // @codingStandardsIgnoreEnd
+            if (preg_match($regExp, $content, $m)) {
+                $dependencies = array_filter(explode(',', rtrim(preg_replace('/[\s"\']/', '', $m[1]), ',')));
+
+                if ($dependencies) {
+                    return [$moduleName => $dependencies];
+                }
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -285,7 +285,9 @@ class ComponentInstaller implements
             $regExp = '/public\s+function\s+getModuleDependencies\s*\(\s*\)\s*{[^}]*return\s*(?:array\(|\[)([^})\]]*)(\)|\])/';
             // @codingStandardsIgnoreEnd
             if (preg_match($regExp, $content, $m)) {
-                $dependencies = array_filter(explode(',', rtrim(preg_replace('/[\s"\']/', '', $m[1]), ',')));
+                $dependencies = array_filter(
+                    explode(',', stripslashes(rtrim(preg_replace('/[\s"\']/', '', $m[1]), ',')))
+                );
 
                 if ($dependencies) {
                     return [$moduleName => $dependencies];

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -137,4 +137,12 @@ class ConfigInjectorChain implements InjectorInterface
     {
         return $this;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setModuleDependencies(array $modules)
+    {
+        return $this;
+    }
 }

--- a/src/Injector/InjectorInterface.php
+++ b/src/Injector/InjectorInterface.php
@@ -65,4 +65,12 @@ interface InjectorInterface
      * @return self
      */
     public function setApplicationModules(array $modules);
+
+    /**
+     * Set dependencies for the module.
+     *
+     * @param array $modules
+     * @return self
+     */
+    public function setModuleDependencies(array $modules);
 }

--- a/src/Injector/NoopInjector.php
+++ b/src/Injector/NoopInjector.php
@@ -58,4 +58,12 @@ class NoopInjector implements InjectorInterface
     {
         return $this;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setModuleDependencies(array $modules)
+    {
+        return $this;
+    }
 }

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -1445,4 +1445,32 @@ CONTENT
             'Some\Module',
         ], $modules);
     }
+
+    public function moduleClass()
+    {
+        return [
+            [__DIR__ . '/TestAsset/ModuleBadlyFormatted.php', ['BadlyFormatted\Application' => ['Dependency1']]],
+            [__DIR__ . '/TestAsset/ModuleWithDependencies.php', ['MyNamespace' => ['Dependency']]],
+            [__DIR__ . '/TestAsset/ModuleWithInterface.php', ['LongArray\Application' => ['D1', 'D2']]],
+            [__DIR__ . '/TestAsset/ModuleWithoutDependencies.php', []],
+            [__DIR__ . '/TestAsset/ModuleWithEmptyArrayDependencies.php', []],
+        ];
+    }
+
+    /**
+     * @dataProvider moduleClass
+     *
+     * @param string $file
+     * @param array $result
+     */
+    public function testGetModuleDependenciesFromModuleClass($file, $result)
+    {
+        $r = new \ReflectionObject($this->installer);
+        $rm = $r->getMethod('getModuleDependencies');
+        $rm->setAccessible(true);
+
+        $dependencies = $rm->invoke($this->installer, $file);
+
+        $this->assertEquals($result, $dependencies);
+    }
 }

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -1451,7 +1451,7 @@ CONTENT
         return [
             [__DIR__ . '/TestAsset/ModuleBadlyFormatted.php', ['BadlyFormatted\Application' => ['Dependency1']]],
             [__DIR__ . '/TestAsset/ModuleWithDependencies.php', ['MyNamespace' => ['Dependency']]],
-            [__DIR__ . '/TestAsset/ModuleWithInterface.php', ['LongArray\Application' => ['D1', 'D2']]],
+            [__DIR__ . '/TestAsset/ModuleWithInterface.php', ['LongArray\Application' => ['Foo\D1', 'Bar\D2']]],
             [__DIR__ . '/TestAsset/ModuleWithoutDependencies.php', []],
             [__DIR__ . '/TestAsset/ModuleWithEmptyArrayDependencies.php', []],
         ];

--- a/test/TestAsset/ModuleBadlyFormatted.php
+++ b/test/TestAsset/ModuleBadlyFormatted.php
@@ -1,0 +1,14 @@
+<?php
+namespace
+  BadlyFormatted\Application
+
+;
+
+class Module{
+    public function
+    getModuleDependencies(){
+        return
+
+        [    "Dependency1" ];
+    }
+}

--- a/test/TestAsset/ModuleWithDependencies.php
+++ b/test/TestAsset/ModuleWithDependencies.php
@@ -1,0 +1,10 @@
+<?php
+namespace MyNamespace;
+
+class Module
+{
+    public function getModuleDependencies()
+    {
+        return ['Dependency'];
+    }
+}

--- a/test/TestAsset/ModuleWithEmptyArrayDependencies.php
+++ b/test/TestAsset/ModuleWithEmptyArrayDependencies.php
@@ -1,0 +1,10 @@
+<?php
+namespace Foo\NewApplication;
+
+class Module
+{
+    public function getModuleDependencies()
+    {
+        return [];
+    }
+}

--- a/test/TestAsset/ModuleWithInterface.php
+++ b/test/TestAsset/ModuleWithInterface.php
@@ -8,8 +8,8 @@ class Module implements SomeInterface
     public function getModuleDependencies()
     {
         return array(
-            'D1',
-            'D2',
+            'Foo\\D1',
+            'Bar\\D2',
         );
     }
 }

--- a/test/TestAsset/ModuleWithInterface.php
+++ b/test/TestAsset/ModuleWithInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace LongArray\Application;
+
+use ClassMap\SomeInterface;
+
+class Module implements SomeInterface
+{
+    public function getModuleDependencies()
+    {
+        return array(
+            'D1',
+            'D2',
+        );
+    }
+}

--- a/test/TestAsset/ModuleWithoutDependencies.php
+++ b/test/TestAsset/ModuleWithoutDependencies.php
@@ -1,0 +1,10 @@
+<?php
+namespace MyNamespace;
+
+class Module
+{
+    public function getConfig()
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
Alternative solution to #23.
Module classes are no longer included. In this solution we are using regular expression to extract method `getModuleDependencies`.

Probably using some tokenizer can give better results (and would be more reliable?), but then we have to add this library in require section of composer. I'm not sure if we want to do that...

What do you think? Or maybe you have another idea how we can resolve this issue?
