### PR TITLE
Fix for #22

### DIFF
--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -372,6 +372,7 @@ abstract class AbstractInjector implements InjectorInterface
      */
     protected function isRegisteredInConfig($package, $config)
     {
-        return (1 === preg_match(sprintf($this->isRegisteredPattern, preg_quote($package, '/')), $config));
+        return preg_match(sprintf($this->isRegisteredPattern, preg_quote($package, '/')), $config)
+            || preg_match(sprintf($this->isRegisteredPattern, preg_quote(addslashes($package), '/')), $config);
     }
 }

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -46,10 +46,11 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
     {
         // @codingStandardsIgnoreStart
         return [
-            'component-long-array'  => ['<' . "?php\nreturn array(\n    'modules' => array(\n        'Foo\Bar',\n        'Application',\n    )\n);", ApplicationConfigInjector::TYPE_COMPONENT],
-            'component-short-array' => ['<' . "?php\nreturn [\n    'modules' => [\n        'Foo\Bar',\n        'Application',\n    ]\n];",           ApplicationConfigInjector::TYPE_COMPONENT],
-            'module-long-array'     => ['<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n        'Foo\Bar',\n    )\n);", ApplicationConfigInjector::TYPE_MODULE],
-            'module-short-array'    => ['<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n        'Foo\Bar',\n    ]\n];",           ApplicationConfigInjector::TYPE_MODULE],
+            'component-long-array'      => ['<' . "?php\nreturn array(\n    'modules' => array(\n        'Foo\Bar',\n        'Application',\n    )\n);", ApplicationConfigInjector::TYPE_COMPONENT],
+            'component-short-array'     => ['<' . "?php\nreturn [\n    'modules' => [\n        'Foo\Bar',\n        'Application',\n    ]\n];",           ApplicationConfigInjector::TYPE_COMPONENT],
+            'component-escaped-slashes' => ['<' . "?php\nreturn [\n    'modules' => [\n        'Foo\\\\Bar',\n        'Application',\n    ]\n];",           ApplicationConfigInjector::TYPE_COMPONENT],
+            'module-long-array'         => ['<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n        'Foo\Bar',\n    )\n);", ApplicationConfigInjector::TYPE_MODULE],
+            'module-short-array'        => ['<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n        'Foo\Bar',\n    ]\n];",           ApplicationConfigInjector::TYPE_MODULE],
         ];
         // @codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
As noted by author of the issue - @eimanavicius the problem occurs in Apigility.
By default in `modules.config.php` all packages are without slashes, but after adding new api in apigility admin, when the file is updated, escaped slashes are added.
It could cause issue when component installer check later on if module without escaped slashes is enabled and will add it again. In normal situation is shouldn't happen because component installer is only invoked on _post package install_ but it is possible to hit this edge case for example on checking for some dependencies.

We can fix it in apigility admin - to not adding these extra escaping slashes, but I think this library should be a bit more flexible and detect this situation better. Please have a look on my simply fix which resolve issue.

/cc @eimanavicius
