### PR TITLE
Allow injecting ConfigAggregator-based config files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,15 @@ matrix:
     - php: 7
       env:
         - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=locked
+    - php: 7.1
+      env:
+        - DEPS=latest
     - php: hhvm
       env:
         - DEPS=lowest

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -20,7 +20,10 @@ class ConfigDiscovery
             'dist' => ConfigDiscovery\DevelopmentConfig::class,
             'work' => ConfigDiscovery\DevelopmentWorkConfig::class,
         ],
-        'config/config.php' => ConfigDiscovery\ExpressiveConfig::class,
+        'config/config.php' => [
+            'aggregator' => ConfigDiscovery\ConfigAggregator::class,
+            'manager'    => ConfigDiscovery\ExpressiveConfig::class,
+        ],
     ];
 
     /**
@@ -35,7 +38,10 @@ class ConfigDiscovery
             'dist' => Injector\DevelopmentConfigInjector::class,
             'work' => Injector\DevelopmentWorkConfigInjector::class,
         ],
-        'config/config.php' => Injector\ExpressiveConfigInjector::class,
+        'config/config.php' => [
+            'aggregator' => Injector\ConfigAggregatorInjector::class,
+            'manager'    => Injector\ExpressiveConfigInjector::class,
+        ]
     ];
 
     /**
@@ -56,7 +62,7 @@ class ConfigDiscovery
         ]);
 
         Collection::create($this->discovery)
-            // Create a discovery class for the dicovery type
+            // Create a discovery class for the discovery type
             ->map(function ($discoveryClass) use ($projectRoot) {
                 if (is_array($discoveryClass)) {
                     return new ConfigDiscovery\DiscoveryChain($discoveryClass, $projectRoot);

--- a/src/ConfigDiscovery/ConfigAggregator.php
+++ b/src/ConfigDiscovery/ConfigAggregator.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ */
+
+namespace Zend\ComponentInstaller\ConfigDiscovery;
+
+class ConfigAggregator extends AbstractDiscovery
+{
+    /**
+     * Configuration file to look for.
+     *
+     * @var string
+     */
+    protected $configFile = 'config/config.php';
+
+    /**
+     * Expected pattern to match if the configuration file exists.
+     *
+     * Pattern is set in constructor to ensure PCRE quoting is correct.
+     *
+     * @var string
+     */
+    protected $expected = '';
+
+    public function __construct($projectDirectory = '')
+    {
+        $this->expected = sprintf(
+            '/new (?:%s?%s)?ConfigAggregator\(\s*(?:array\(|\[)/s',
+            preg_quote('\\'),
+            preg_quote('Zend\ConfigAggregator\\')
+        );
+
+        parent::__construct($projectDirectory);
+    }
+}

--- a/src/Injector/ConditionalDiscoveryTrait.php
+++ b/src/Injector/ConditionalDiscoveryTrait.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ */
+
+namespace Zend\ComponentInstaller\Injector;
+
+use Composer\IO\IOInterface;
+
+trait ConditionalDiscoveryTrait
+{
+    /**
+     * {@inheritDoc}
+     *
+     * Prepends the package with a `\\` in order to ensure it is fully
+     * qualified, preventing issues in config files that are namespaced.
+     */
+    public function inject($package, $type, IOInterface $io)
+    {
+        if (! $this->validConfigAggregatorConfig()) {
+            return;
+        }
+
+        parent::inject('\\' . $package, $type, $io);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Prepends the package with a `\\` in order to ensure it is fully
+     * qualified, preventing issues in config files that are namespaced.
+     */
+    public function remove($package, IOInterface $io)
+    {
+        if (! $this->validConfigAggregatorConfig()) {
+            return;
+        }
+
+        parent::remove('\\' . $package, $io);
+    }
+
+    /**
+     * Does the config file hold valid ConfigAggregator configuration?
+     *
+     * @return bool
+     */
+    private function validConfigAggregatorConfig()
+    {
+        $discoveryClass = $this->discoveryClass;
+        $discovery = new $discoveryClass($this->getProjectRoot());
+        return $discovery->locate();
+    }
+
+    /**
+     * Calculate the project root from the config file
+     *
+     * @return string
+     */
+    private function getProjectRoot()
+    {
+        if (static::DEFAULT_CONFIG_FILE === $this->configFile) {
+            return '';
+        }
+        return str_replace('/' . static::DEFAULT_CONFIG_FILE, '', $this->configFile);
+    }
+}

--- a/src/Injector/ConfigAggregatorInjector.php
+++ b/src/Injector/ConfigAggregatorInjector.php
@@ -46,7 +46,7 @@ class ConfigAggregatorInjector extends AbstractInjector
     protected $injectionPatterns = [
         self::TYPE_CONFIG_PROVIDER => [
             'pattern'     => '',
-            'replacement' => "\$1\n    %s::class,",
+            'replacement' => "\$1\n\$2%s::class,\n\$2",
         ],
     ];
 
@@ -84,7 +84,7 @@ class ConfigAggregatorInjector extends AbstractInjector
             . ')?ConfigAggregator\(\s*(?:array\(|\[).*\s+%s::class/s';
 
         $this->injectionPatterns[self::TYPE_CONFIG_PROVIDER]['pattern'] = sprintf(
-            '/(new (?:%s?%s)?ConfigAggregator\(\s*(?:array\(|\[)\s*)$/m',
+            "/(new (?:%s?%s)?ConfigAggregator\(\s*(?:array\(|\[)\s*)(?:\r|\n|\r\n)(\s*)/",
             preg_quote('\\'),
             preg_quote('Zend\ConfigAggregator\\')
         );

--- a/src/Injector/ConfigAggregatorInjector.php
+++ b/src/Injector/ConfigAggregatorInjector.php
@@ -6,9 +6,9 @@
 
 namespace Zend\ComponentInstaller\Injector;
 
-use Zend\ComponentInstaller\ConfigDiscovery\ExpressiveConfig as ExpressiveConfigDiscovery;
+use Zend\ComponentInstaller\ConfigDiscovery\ConfigAggregator as ConfigAggregatorDiscovery;
 
-class ExpressiveConfigInjector extends AbstractInjector
+class ConfigAggregatorInjector extends AbstractInjector
 {
     use ConditionalDiscoveryTrait;
 
@@ -34,7 +34,7 @@ class ExpressiveConfigInjector extends AbstractInjector
      *
      * @var string
      */
-    protected $discoveryClass = ExpressiveConfigDiscovery::class;
+    protected $discoveryClass = ConfigAggregatorDiscovery::class;
 
     /**
      * Patterns and replacements to use when registering a code item.
@@ -80,13 +80,13 @@ class ExpressiveConfigInjector extends AbstractInjector
         $this->isRegisteredPattern = '/new (?:'
             . preg_quote('\\')
             . '?'
-            . preg_quote('Zend\Expressive\ConfigManager\\')
-            . ')?ConfigManager\(\s*(?:array\(|\[).*\s+%s::class/s';
+            . preg_quote('Zend\ConfigAggregator\\')
+            . ')?ConfigAggregator\(\s*(?:array\(|\[).*\s+%s::class/s';
 
         $this->injectionPatterns[self::TYPE_CONFIG_PROVIDER]['pattern'] = sprintf(
-            '/(new (?:%s?%s)?ConfigManager\(\s*(?:array\(|\[)\s*)$/m',
+            '/(new (?:%s?%s)?ConfigAggregator\(\s*(?:array\(|\[)\s*)$/m',
             preg_quote('\\'),
-            preg_quote('Zend\Expressive\ConfigManager\\')
+            preg_quote('Zend\ConfigAggregator\\')
         );
 
         parent::__construct($projectRoot);

--- a/test/ConfigDiscovery/ConfigAggregatorTest.php
+++ b/test/ConfigDiscovery/ConfigAggregatorTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ */
+
+namespace ZendTest\ComponentInstaller\ConfigDiscovery;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\ComponentInstaller\ConfigDiscovery\ConfigAggregator;
+
+class ConfigAggregatorTest extends TestCase
+{
+    private $configDir;
+
+    private $locator;
+
+    public function setUp()
+    {
+        $this->configDir = vfsStream::setup('project');
+        $this->locator = new ConfigAggregator(
+            vfsStream::url('project')
+        );
+    }
+
+    public function testAbsenceOfFileReturnsFalseOnLocate()
+    {
+        $this->assertFalse($this->locator->locate());
+    }
+
+    public function testLocateReturnsFalseWhenFileDoesNotHaveExpectedContents()
+    {
+        vfsStream::newFile('config/config.php')
+            ->at($this->configDir)
+            ->setContent('<' . "?php\nreturn [];");
+        $this->assertFalse($this->locator->locate());
+    }
+
+    public function validExpressiveConfigContents()
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            'fqcn-short-array'               => ['<' . "?php\n\$aggregator = new Zend\ConfigAggregator\ConfigAggregator([\n]);"],
+            'globally-qualified-short-array' => ['<' . "?php\n\$aggregator = new \Zend\ConfigAggregator\ConfigAggregator([\n]);"],
+            'imported-short-array'           => ['<' . "?php\n\$aggregator = new ConfigAggregator([\n]);"],
+            'fqcn-long-array'                => ['<' . "?php\n\$aggregator = new Zend\ConfigAggregator\ConfigAggregator(array(\n));"],
+            'globally-qualified-long-array'  => ['<' . "?php\n\$aggregator = new \Zend\ConfigAggregator\ConfigAggregator(array(\n));"],
+            'imported-long-array'            => ['<' . "?php\n\$aggregator = new ConfigAggregator(array(\n));"],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider validExpressiveConfigContents
+     */
+    public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
+    {
+        vfsStream::newFile('config/config.php')
+            ->at($this->configDir)
+            ->setContent($contents);
+
+        $this->assertTrue($this->locator->locate());
+    }
+}

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -36,8 +36,9 @@ class ConfigDiscoveryTest extends TestCase
 
         $this->injectorTypes = [
             Injector\ApplicationConfigInjector::class,
+            // Injector\ConfigAggregatorInjector::class,
             Injector\ConfigInjectorChain::class,
-            Injector\ExpressiveConfigInjector::class,
+            // Injector\ExpressiveConfigInjector::class,
             Injector\ModulesConfigInjector::class,
         ];
     }
@@ -60,6 +61,13 @@ class ConfigDiscoveryTest extends TestCase
     public function createDevelopmentWorkConfig()
     {
         $this->createDevelopmentConfig(false);
+    }
+
+    public function createAggregatorConfig()
+    {
+        vfsStream::newFile('config/config.php')
+            ->at($this->projectRoot)
+            ->setContent('<' . "?php\n\$aggregator = new ConfigAggregator([\n]);");
     }
 
     public function createExpressiveConfig()
@@ -145,6 +153,7 @@ class ConfigDiscoveryTest extends TestCase
     {
         $this->createApplicationConfig();
         $this->createDevelopmentConfig();
+        $this->createAggregatorConfig();
         $this->createExpressiveConfig();
         $this->createModulesConfig();
 
@@ -173,6 +182,18 @@ class ConfigDiscoveryTest extends TestCase
                 'chain'      => false,
             ],
             [
+                'seedMethod' => 'createAggregatorConfig',
+                'type'       => InjectorInterface::TYPE_CONFIG_PROVIDER,
+                'expected'   => Injector\ConfigAggregatorInjector::class,
+                'chain'      => true,
+            ],
+            [
+                'seedMethod' => 'createAggregatorConfig',
+                'type'       => InjectorInterface::TYPE_CONFIG_PROVIDER,
+                'expected'   => Injector\ConfigAggregatorInjector::class,
+                'chain'      => true,
+            ],
+            [
                 'seedMethod' => 'createDevelopmentConfig',
                 'type'       => InjectorInterface::TYPE_COMPONENT,
                 'expected'   => Injector\DevelopmentConfigInjector::class,
@@ -200,13 +221,13 @@ class ConfigDiscoveryTest extends TestCase
                 'seedMethod' => 'createExpressiveConfig',
                 'type'       => InjectorInterface::TYPE_CONFIG_PROVIDER,
                 'expected'   => Injector\ExpressiveConfigInjector::class,
-                'chain'      => false,
+                'chain'      => true,
             ],
             [
                 'seedMethod' => 'createExpressiveConfig',
                 'type'       => InjectorInterface::TYPE_CONFIG_PROVIDER,
                 'expected'   => Injector\ExpressiveConfigInjector::class,
-                'chain'      => false,
+                'chain'      => true,
             ],
             [
                 'seedMethod' => 'createModulesConfig',

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ */
+
+namespace ZendTest\ComponentInstaller\Injector;
+
+use Zend\ComponentInstaller\Injector\ConfigAggregatorInjector;
+
+class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
+{
+    protected $configFile = 'config/config.php';
+
+    protected $injectorClass = ConfigAggregatorInjector::class;
+
+    protected $injectorTypesAllowed = [
+        ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER,
+    ];
+
+    public function convertToShortArraySyntax($contents)
+    {
+        return preg_replace('/array\(([^)]+)\)/s', '[$1]', $contents);
+    }
+
+    public function allowedTypes()
+    {
+        return [
+            'config-provider' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, true],
+            'component'       => [ConfigAggregatorInjector::TYPE_COMPONENT, false],
+            'module'          => [ConfigAggregatorInjector::TYPE_MODULE, false],
+        ];
+    }
+
+    public function injectComponentProvider()
+    {
+        // @codingStandardsIgnoreStart
+        $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-application-fqcn.config.php');
+        $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-application-globally-qualified.config.php');
+        $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import.config.php');
+
+        $baseContentsFqcnShortArray              = $this->convertToShortArraySyntax($baseContentsFqcnLongArray);
+        $baseContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($baseContentsGloballyQualifiedLongArray);
+        $baseContentsImportShortArray            = $this->convertToShortArraySyntax($baseContentsImportLongArray);
+
+        $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
+        $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
+        $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+
+        $expectedContentsFqcnShortArray              = $this->convertToShortArraySyntax($expectedContentsFqcnLongArray);
+        $expectedContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($expectedContentsGloballyQualifiedLongArray);
+        $expectedContentsImportShortArray            = $this->convertToShortArraySyntax($expectedContentsImportLongArray);
+
+        return [
+            'fqcn-long-array'           => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
+            'global-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
+            'import-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
+            'fqcn-short-array'          => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
+            'global-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
+            'import-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    public function packageAlreadyRegisteredProvider()
+    {
+        // @codingStandardsIgnoreStart
+        $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
+        $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
+        $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+
+        $fqcnShortArray              = $this->convertToShortArraySyntax($fqcnLongArray);
+        $globallyQualifiedShortArray = $this->convertToShortArraySyntax($globallyQualifiedLongArray);
+        $importShortArray            = $this->convertToShortArraySyntax($importLongArray);
+
+        return [
+            'fqcn-long-array'           => [$fqcnLongArray,               ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER],
+            'global-long-array'         => [$globallyQualifiedLongArray,  ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER],
+            'import-long-array'         => [$importLongArray,             ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER],
+            'fqcn-short-array'          => [$fqcnShortArray,              ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER],
+            'global-short-array'        => [$globallyQualifiedShortArray, ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER],
+            'import-short-array'        => [$importShortArray,            ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    public function emptyConfiguration()
+    {
+        // @codingStandardsIgnoreStart
+        $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-fqcn.config.php');
+        $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-globally-qualified.config.php');
+        $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-import.config.php');
+
+        $fqcnShortArray              = $this->convertToShortArraySyntax($fqcnLongArray);
+        $globallyQualifiedShortArray = $this->convertToShortArraySyntax($globallyQualifiedLongArray);
+        $importShortArray            = $this->convertToShortArraySyntax($importLongArray);
+
+        return [
+            'fqcn-long-array'           => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
+            'global-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
+            'import-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
+            'fqcn-short-array'          => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
+            'global-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
+            'import-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    public function packagePopulatedInConfiguration()
+    {
+        // @codingStandardsIgnoreStart
+        $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
+        $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
+        $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+
+        $baseContentsFqcnShortArray              = $this->convertToShortArraySyntax($baseContentsFqcnLongArray);
+        $baseContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($baseContentsGloballyQualifiedLongArray);
+        $baseContentsImportShortArray            = $this->convertToShortArraySyntax($baseContentsImportLongArray);
+
+        $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-application-fqcn.config.php');
+        $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-application-globally-qualified.config.php');
+        $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import.config.php');
+
+        $expectedContentsFqcnShortArray              = $this->convertToShortArraySyntax($expectedContentsFqcnLongArray);
+        $expectedContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($expectedContentsGloballyQualifiedLongArray);
+        $expectedContentsImportShortArray            = $this->convertToShortArraySyntax($expectedContentsImportLongArray);
+
+        return [
+            'fqcn-long-array'    => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
+            'global-long-array'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
+            'import-long-array'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
+            'fqcn-short-array'   => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
+            'global-short-array' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
+            'import-short-array' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+}

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -38,26 +38,32 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-application-fqcn.config.php');
         $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-application-globally-qualified.config.php');
         $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import.config.php');
+        $baseContentsImportLongArrayAltIndent   = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import-alt-indent.config.php');
 
         $baseContentsFqcnShortArray              = $this->convertToShortArraySyntax($baseContentsFqcnLongArray);
         $baseContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($baseContentsGloballyQualifiedLongArray);
         $baseContentsImportShortArray            = $this->convertToShortArraySyntax($baseContentsImportLongArray);
+        $baseContentsImportShortArrayAltIndent   = $this->convertToShortArraySyntax($baseContentsImportLongArrayAltIndent);
 
         $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
         $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
         $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+        $expectedContentsImportLongArrayAltIndent   = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import-alt-indent.config.php');
 
         $expectedContentsFqcnShortArray              = $this->convertToShortArraySyntax($expectedContentsFqcnLongArray);
         $expectedContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($expectedContentsGloballyQualifiedLongArray);
         $expectedContentsImportShortArray            = $this->convertToShortArraySyntax($expectedContentsImportLongArray);
+        $expectedContentsImportShortArrayAltIndent   = $this->convertToShortArraySyntax($expectedContentsImportLongArrayAltIndent);
 
         return [
-            'fqcn-long-array'           => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
-            'global-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
-            'import-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
-            'fqcn-short-array'          => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
-            'global-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
-            'import-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+            'fqcn-long-array'               => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
+            'global-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
+            'import-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
+            'import-long-array-alt-indent'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArrayAltIndent,    $expectedContentsImportLongArrayAltIndent],
+            'fqcn-short-array'              => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
+            'global-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
+            'import-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+            'import-short-array-alt-indent' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArrayAltIndent,   $expectedContentsImportShortArrayAltIndent],
         ];
         // @codingStandardsIgnoreEnd
     }
@@ -112,26 +118,32 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
         $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
         $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+        $baseContentsImportLongArrayAltIndent   = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import-alt-indent.config.php');
 
         $baseContentsFqcnShortArray              = $this->convertToShortArraySyntax($baseContentsFqcnLongArray);
         $baseContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($baseContentsGloballyQualifiedLongArray);
         $baseContentsImportShortArray            = $this->convertToShortArraySyntax($baseContentsImportLongArray);
+        $baseContentsImportShortArrayAltIndent   = $this->convertToShortArraySyntax($baseContentsImportLongArrayAltIndent);
 
         $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-application-fqcn.config.php');
         $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-application-globally-qualified.config.php');
         $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import.config.php');
+        $expectedContentsImportLongArrayAltIndent   = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import-alt-indent.config.php');
 
         $expectedContentsFqcnShortArray              = $this->convertToShortArraySyntax($expectedContentsFqcnLongArray);
         $expectedContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($expectedContentsGloballyQualifiedLongArray);
         $expectedContentsImportShortArray            = $this->convertToShortArraySyntax($expectedContentsImportLongArray);
+        $expectedContentsImportShortArrayAltIndent   = $this->convertToShortArraySyntax($expectedContentsImportLongArrayAltIndent);
 
         return [
-            'fqcn-long-array'    => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
-            'global-long-array'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
-            'import-long-array'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
-            'fqcn-short-array'   => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
-            'global-short-array' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
-            'import-short-array' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+            'fqcn-long-array'               => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
+            'global-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
+            'import-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
+            'import-long-array-alt-indent'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArrayAltIndent,    $expectedContentsImportLongArrayAltIndent],
+            'fqcn-short-array'              => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
+            'global-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
+            'import-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+            'import-short-array-alt-indent' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArrayAltIndent,   $expectedContentsImportShortArrayAltIndent],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/ExpressiveConfigInjectorTest.php
+++ b/test/Injector/ExpressiveConfigInjectorTest.php
@@ -96,12 +96,12 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
         $importShortArray            = $this->convertToShortArraySyntax($importLongArray);
 
         return [
-            'legacy-fqcn-long-array'    => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
-            'legacy-global-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
-            'legacy-import-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
-            'legacy-fqcn-short-array'   => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
-            'legacy-global-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
-            'legacy-import-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
+            'fqcn-long-array'    => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
+            'global-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
+            'import-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
+            'fqcn-short-array'   => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
+            'global-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
+            'import-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/ExpressiveConfigInjectorTest.php
+++ b/test/Injector/ExpressiveConfigInjectorTest.php
@@ -35,17 +35,17 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
     public function injectComponentProvider()
     {
         // @codingStandardsIgnoreStart
-        $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-application-fqcn.config.php');
-        $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-application-globally-qualified.config.php');
-        $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import.config.php');
+        $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-application-fqcn.config.php');
+        $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-application-globally-qualified.config.php');
+        $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-application-import.config.php');
 
         $baseContentsFqcnShortArray              = $this->convertToShortArraySyntax($baseContentsFqcnLongArray);
         $baseContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($baseContentsGloballyQualifiedLongArray);
         $baseContentsImportShortArray            = $this->convertToShortArraySyntax($baseContentsImportLongArray);
 
-        $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
-        $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
-        $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+        $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-fqcn.config.php');
+        $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-globally-qualified.config.php');
+        $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-import.config.php');
 
         $expectedContentsFqcnShortArray              = $this->convertToShortArraySyntax($expectedContentsFqcnLongArray);
         $expectedContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($expectedContentsGloballyQualifiedLongArray);
@@ -65,9 +65,9 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
     public function packageAlreadyRegisteredProvider()
     {
         // @codingStandardsIgnoreStart
-        $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
-        $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
-        $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+        $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-fqcn.config.php');
+        $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-globally-qualified.config.php');
+        $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-import.config.php');
 
         $fqcnShortArray              = $this->convertToShortArraySyntax($fqcnLongArray);
         $globallyQualifiedShortArray = $this->convertToShortArraySyntax($globallyQualifiedLongArray);
@@ -87,21 +87,21 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
     public function emptyConfiguration()
     {
         // @codingStandardsIgnoreStart
-        $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-fqcn.config.php');
-        $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-globally-qualified.config.php');
-        $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-import.config.php');
+        $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-empty-fqcn.config.php');
+        $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-empty-globally-qualified.config.php');
+        $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-empty-import.config.php');
 
         $fqcnShortArray              = $this->convertToShortArraySyntax($fqcnLongArray);
         $globallyQualifiedShortArray = $this->convertToShortArraySyntax($globallyQualifiedLongArray);
         $importShortArray            = $this->convertToShortArraySyntax($importLongArray);
 
         return [
-            'fqcn-long-array'    => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
-            'global-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
-            'import-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
-            'fqcn-short-array'   => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
-            'global-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
-            'import-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
+            'legacy-fqcn-long-array'    => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
+            'legacy-global-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
+            'legacy-import-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
+            'legacy-fqcn-short-array'   => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
+            'legacy-global-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
+            'legacy-import-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
         ];
         // @codingStandardsIgnoreEnd
     }
@@ -109,17 +109,17 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
     public function packagePopulatedInConfiguration()
     {
         // @codingStandardsIgnoreStart
-        $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-fqcn.config.php');
-        $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-globally-qualified.config.php');
-        $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-populated-import.config.php');
+        $baseContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-fqcn.config.php');
+        $baseContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-globally-qualified.config.php');
+        $baseContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-populated-import.config.php');
 
         $baseContentsFqcnShortArray              = $this->convertToShortArraySyntax($baseContentsFqcnLongArray);
         $baseContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($baseContentsGloballyQualifiedLongArray);
         $baseContentsImportShortArray            = $this->convertToShortArraySyntax($baseContentsImportLongArray);
 
-        $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-application-fqcn.config.php');
-        $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-application-globally-qualified.config.php');
-        $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-application-import.config.php');
+        $expectedContentsFqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-application-fqcn.config.php');
+        $expectedContentsGloballyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-application-globally-qualified.config.php');
+        $expectedContentsImportLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-application-import.config.php');
 
         $expectedContentsFqcnShortArray              = $this->convertToShortArraySyntax($expectedContentsFqcnLongArray);
         $expectedContentsGloballyQualifiedShortArray = $this->convertToShortArraySyntax($expectedContentsGloballyQualifiedLongArray);

--- a/test/Injector/TestAsset/expressive-application-fqcn.config.php
+++ b/test/Injector/TestAsset/expressive-application-fqcn.config.php
@@ -1,7 +1,7 @@
 <?php
 
-$configManager = new Zend\Expressive\ConfigManager\ConfigManager(array(
+$aggregator = new Zend\ConfigAggregator\ConfigAggregator(array(
     Application\ConfigProvider::class,
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-application-globally-qualified.config.php
+++ b/test/Injector/TestAsset/expressive-application-globally-qualified.config.php
@@ -1,7 +1,7 @@
 <?php
 
-$configManager = new \Zend\Expressive\ConfigManager\ConfigManager(array(
+$aggregator = new \Zend\ConfigAggregator\ConfigAggregator(array(
     \Application\ConfigProvider::class,
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-application-import-alt-indent.config.php
+++ b/test/Injector/TestAsset/expressive-application-import-alt-indent.config.php
@@ -1,0 +1,11 @@
+<?php
+use Zend\ConfigAggregator\ConfigAggregator;
+
+$aggregator = new ConfigAggregator(
+    array(
+        Application\ConfigProvider::class,
+    ),
+    'data/cache/config.php'
+);
+
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-application-import.config.php
+++ b/test/Injector/TestAsset/expressive-application-import.config.php
@@ -1,8 +1,8 @@
 <?php
-use Zend\Expressive\ConfigManager\ConfigManager;
+use Zend\ConfigAggregator\ConfigAggregator;
 
-$configManager = new ConfigManager(array(
+$aggregator = new ConfigAggregator(array(
     Application\ConfigProvider::class,
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-empty-fqcn.config.php
+++ b/test/Injector/TestAsset/expressive-empty-fqcn.config.php
@@ -1,6 +1,6 @@
 <?php
 
-$configManager = new Zend\Expressive\ConfigManager\ConfigManager(array(
+$aggregator = new Zend\ConfigAggregator\ConfigAggregator(array(
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-empty-globally-qualified.config.php
+++ b/test/Injector/TestAsset/expressive-empty-globally-qualified.config.php
@@ -1,6 +1,6 @@
 <?php
 
-$configManager = new \Zend\Expressive\ConfigManager\ConfigManager(array(
+$aggregator = new \Zend\ConfigAggregator\ConfigAggregator(array(
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-empty-import.config.php
+++ b/test/Injector/TestAsset/expressive-empty-import.config.php
@@ -1,7 +1,7 @@
 <?php
-use Zend\Expressive\ConfigManager\ConfigManager;
+use Zend\ConfigAggregator\ConfigAggregator;
 
-$configManager = new ConfigManager(array(
+$aggregator = new ConfigAggregator(array(
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-populated-fqcn.config.php
+++ b/test/Injector/TestAsset/expressive-populated-fqcn.config.php
@@ -1,8 +1,8 @@
 <?php
 
-$configManager = new Zend\Expressive\ConfigManager\ConfigManager(array(
+$aggregator = new Zend\ConfigAggregator\ConfigAggregator(array(
     \Foo\Bar::class,
     Application\ConfigProvider::class,
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-populated-globally-qualified.config.php
+++ b/test/Injector/TestAsset/expressive-populated-globally-qualified.config.php
@@ -1,8 +1,8 @@
 <?php
 
-$configManager = new \Zend\Expressive\ConfigManager\ConfigManager(array(
+$aggregator = new \Zend\ConfigAggregator\ConfigAggregator(array(
     \Foo\Bar::class,
     \Application\ConfigProvider::class,
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-populated-import-alt-indent.config.php
+++ b/test/Injector/TestAsset/expressive-populated-import-alt-indent.config.php
@@ -1,0 +1,12 @@
+<?php
+use Zend\ConfigAggregator\ConfigAggregator;
+
+$aggregator = new ConfigAggregator(
+    array(
+        \Foo\Bar::class,
+        Application\ConfigProvider::class,
+    ),
+    'data/cache/config.php'
+);
+
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/expressive-populated-import.config.php
+++ b/test/Injector/TestAsset/expressive-populated-import.config.php
@@ -1,9 +1,9 @@
 <?php
-use Zend\Expressive\ConfigManager\ConfigManager;
+use Zend\ConfigAggregator\ConfigAggregator;
 
-$configManager = new ConfigManager(array(
+$aggregator = new ConfigAggregator(array(
     \Foo\Bar::class,
     Application\ConfigProvider::class,
 ), 'data/cache/config.php');
 
-return $configManager->getMergedConfig();
+return $aggregator->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-application-fqcn.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-application-fqcn.config.php
@@ -1,0 +1,7 @@
+<?php
+
+$configManager = new Zend\Expressive\ConfigManager\ConfigManager(array(
+    Application\ConfigProvider::class,
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-application-globally-qualified.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-application-globally-qualified.config.php
@@ -1,0 +1,7 @@
+<?php
+
+$configManager = new \Zend\Expressive\ConfigManager\ConfigManager(array(
+    \Application\ConfigProvider::class,
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-application-import.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-application-import.config.php
@@ -1,0 +1,8 @@
+<?php
+use Zend\Expressive\ConfigManager\ConfigManager;
+
+$configManager = new ConfigManager(array(
+    Application\ConfigProvider::class,
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-empty-fqcn.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-empty-fqcn.config.php
@@ -1,0 +1,6 @@
+<?php
+
+$configManager = new Zend\Expressive\ConfigManager\ConfigManager(array(
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-empty-globally-qualified.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-empty-globally-qualified.config.php
@@ -1,0 +1,6 @@
+<?php
+
+$configManager = new \Zend\Expressive\ConfigManager\ConfigManager(array(
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-empty-import.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-empty-import.config.php
@@ -1,0 +1,7 @@
+<?php
+use Zend\Expressive\ConfigManager\ConfigManager;
+
+$configManager = new ConfigManager(array(
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-populated-fqcn.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-populated-fqcn.config.php
@@ -1,0 +1,8 @@
+<?php
+
+$configManager = new Zend\Expressive\ConfigManager\ConfigManager(array(
+    \Foo\Bar::class,
+    Application\ConfigProvider::class,
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-populated-globally-qualified.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-populated-globally-qualified.config.php
@@ -1,0 +1,8 @@
+<?php
+
+$configManager = new \Zend\Expressive\ConfigManager\ConfigManager(array(
+    \Foo\Bar::class,
+    \Application\ConfigProvider::class,
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();

--- a/test/Injector/TestAsset/legacy-expressive-populated-import.config.php
+++ b/test/Injector/TestAsset/legacy-expressive-populated-import.config.php
@@ -1,0 +1,9 @@
+<?php
+use Zend\Expressive\ConfigManager\ConfigManager;
+
+$configManager = new ConfigManager(array(
+    \Foo\Bar::class,
+    Application\ConfigProvider::class,
+), 'data/cache/config.php');
+
+return $configManager->getMergedConfig();


### PR DESCRIPTION
We recently added zend-config-aggregator, which will supercede zend-config-manager (developed by a third-party contributor as a stepping stone). This patch adds support for ConfigAggregator-based configuration files, while maintaining support for ConfigManager-based files.

In order to make this work, we needed separate discovery and injector files. Since both identify the same filesystem location, this also means an injector chain - and those are intended to run _each_ injector.  Because of that, the existing ExpressiveConfigInjector and the new ConfigAggregatorInjector now use a new trait, ConditionalDiscoveryTrait, which makes use of discovery classes in order to determine if injection/removal is necessary or possible before performing operations.

Fixes #30