### PR TITLE
[BC Break] Refactor and injector interface changes

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,0 +1,5 @@
+/**
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
+ */

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/test export-ignore
+.coveralls.yml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpcs.xml export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
-.buildpath
-.DS_Store
-.idea
-.project
-.settings/
-.*.sw*
-.*.un~
-nbproject
 doc/html/
 vendor/
-zf-mkdoc-theme/
 phpunit.xml
+clover.xml
+coveralls-upload.json
+zf-mkdoc-theme/
+zf-mkdoc-theme.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,20 @@ language: php
 cache:
   directories:
     - $HOME/.composer/cache
-    - vendor
     - $HOME/.local
+    - vendor
     - zf-mkdoc-theme
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - COMPOSER_ARGS="--no-interaction"
+    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - LEGACY_DEPS="phpunit/phpunit"
     - SITE_URL=https://zendframework.github.io/zend-component-installer
     - GH_USER_NAME="Matthew Weier O'Phinney"
     - GH_USER_EMAIL=matthew@weierophinney.net
     - GH_REF=github.com/zendframework/zend-component-installer.git
     - secure: "moDyn4E7j7f2KhiRJK8z5Ps3tJ9EB37MBLQq78NJqmPBRttiCG5PQ2ru62MCQhXKPncjDVd6d9TwA3DRryF49mLqLOYHwYuFM6sgdtRbHi9d5X8jxorsABqFI3d9Wu/A8+vwbmjpw5MPKH96k7n5IaDSCsmsd8jX95gdztybOx+BZ5PY1paJyfwydTo320s9ev0g6yTHlG9LYHhtmPyrog/4Vxsm2yUcEOFLQjY2EwLNTlqQJ3c5LrOaELsZZHwpPTItjX5iQgOs/A3XYsbZHjzFcY4m9wnHryhhTAD5QKyu1kf+XewZfNn+7ROCKGXOJoYb9+mOEL7p3vrQQK9Y16GN2IXn7mAHBJpAefl3aaJFyhf17eyXwDDSCFIBvSZsLZfm/lyJQXhwCuT49sdDDGz3uR5IZ8Zl4n0eiiR7s9QvxNV288zJs7BiWAyU7bRoXe3zkraKbmiqz5LW6ko1Qm3oUzZsRp7oSjzuLg+jO8CccGIY/jhOSaj24tw9aIw8iYNV9/QzR/ncHi/i3v6fOYX+tjoF8Fao9RrBMRkKCywTrm9F9eOO6rDUSHj43eXvQ7awQXoK5DZTwUGwCFkj+2f1FfQw23m8e6dTS4eLdmb2PWQuD28Q/x5+HeAo9TXSJTBsXEGeSTbW/35lMbbtq36eo+3OJnVcQFHNeg3+34U="
-
 
 matrix:
   include:
@@ -27,12 +28,12 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
+        - TEST_COVERAGE=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
         - DEPS=latest
-        - TEST_COVERAGE=true
     - php: 7
       env:
         - DEPS=lowest
@@ -70,21 +71,24 @@ notifications:
 
 before_install:
   - if [[ $TRAVIS_PHP_VERSION != "hhvm" && $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini ; fi
+  - travis_retry composer self-update
 
 install:
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS satooshi/php-coveralls:^1.0 ; fi
-  - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - composer show
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CHECK_CS == 'true' ]]; then composer cs-check ; fi
-  - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then curl -sSL https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh | bash ; fi
+  - if [[ $CHECK_CS == 'true' ]]; then composer license-check ; fi
+  - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then travis_retry curl -sSL https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh | bash ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
 
 after_success:
-  - if [[ $DEPLOY_DOCS == "true" ]]; then ./zf-mkdoc-theme/deploy.sh ; fi
+  - if [[ $DEPLOY_DOCS == "true" ]]; then echo "Preparing to build and deploy documentation" ; ./zf-mkdoc-theme/deploy.sh ; echo "Completed deploying documentation" ; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,234 @@
+# CONTRIBUTING
+
+## RESOURCES
+
+If you wish to contribute to Zend Framework, please be sure to
+read/subscribe to the following resources:
+
+ -  [Coding Standards](https://github.com/zendframework/zf2/wiki/Coding-Standards)
+ -  [Contributor's Guide](CONTRIBUTING.md)
+ -  ZF Contributor's mailing list:
+    Archives: http://zend-framework-community.634137.n4.nabble.com/ZF-Contributor-f680267.html
+    Subscribe: zf-contributors-subscribe@lists.zend.com
+ -  ZF Contributor's IRC channel:
+    #zftalk.dev on Freenode.net
+
+If you are working on new features or refactoring [create a proposal](https://github.com/zendframework/zend-component-installer/issues/new).
+
+## Reporting Potential Security Issues
+
+If you have encountered a potential security vulnerability, please **DO NOT** report it on the public
+issue tracker: send it to us at [zf-security@zend.com](mailto:zf-security@zend.com) instead.
+We will work with you to verify the vulnerability and patch it as soon as possible.
+
+When reporting issues, please provide the following information:
+
+- Component(s) affected
+- A description indicating how to reproduce the issue
+- A summary of the security vulnerability and impact
+
+We request that you contact us via the email address above and give the project
+contributors a chance to resolve the vulnerability and issue a new release prior
+to any public exposure; this helps protect users and provides them with a chance
+to upgrade and/or update in order to protect their applications.
+
+For sensitive email communications, please use [our PGP key](http://framework.zend.com/zf-security-pgp-key.asc).
+
+## RUNNING TESTS
+
+To run tests:
+
+- Clone the repository:
+
+  ```console
+  $ git clone git://github.com/zendframework/zend-component-installer.git
+  $ cd zend-component-installer
+  ```
+
+- Install dependencies via composer:
+
+  ```console
+  $ composer install
+  ```
+
+  If you don't have `composer` installed, please download it from https://getcomposer.org/download/
+
+- Run the tests using the "test" command shipped in the `composer.json`:
+
+  ```console
+  $ composer test
+  ```
+
+You can turn on conditional tests with the `phpunit.xml` file.
+To do so:
+
+ -  Copy `phpunit.xml.dist` file to `phpunit.xml`
+ -  Edit `phpunit.xml` to enable any specific functionality you
+    want to test, as well as to provide test values to utilize.
+
+## Running Coding Standards Checks
+
+First, ensure you've installed dependencies via composer, per the previous
+section on running tests.
+
+To run CS checks only:
+
+```console
+$ composer cs-check
+```
+
+To attempt to automatically fix common CS issues:
+
+```console
+$ composer cs-fix
+```
+
+If the above fixes any CS issues, please re-run the tests to ensure
+they pass, and make sure you add and commit the changes after verification.
+
+## Running License Checks
+
+File-level docblocks should follow the format demonstrated in `.docheader`. To
+check for conformity, use:
+
+```console
+$ composer license-check
+```
+
+This will flag files that are incorrect, which you can then update. Re-run the
+tool to verify your changes.
+
+## Recommended Workflow for Contributions
+
+Your first step is to establish a public repository from which we can
+pull your work into the master repository. We recommend using
+[GitHub](https://github.com), as that is where the component is already hosted.
+
+1. Setup a [GitHub account](https://github.com/), if you haven't yet
+2. Fork the repository (https://github.com/zendframework/zend-component-installer)
+3. Clone the canonical repository locally and enter it.
+
+   ```console
+   $ git clone git://github.com/zendframework/zend-component-installer.git
+   $ cd zend-component-installer
+   ```
+
+4. Add a remote to your fork; substitute your GitHub username in the command
+   below.
+
+   ```console
+   $ git remote add {username} git@github.com:{username}/zend-component-installer.git
+   $ git fetch {username}
+   ```
+
+### Keeping Up-to-Date
+
+Periodically, you should update your fork or personal repository to
+match the canonical ZF repository. Assuming you have setup your local repository
+per the instructions above, you can do the following:
+
+
+```console
+$ git checkout master
+$ git fetch origin
+$ git rebase origin/master
+# OPTIONALLY, to keep your remote up-to-date -
+$ git push {username} master:master
+```
+
+If you're tracking other branches -- for example, the "develop" branch, where
+new feature development occurs -- you'll want to do the same operations for that
+branch; simply substitute  "develop" for "master".
+
+### Working on a patch
+
+We recommend you do each new feature or bugfix in a new branch. This simplifies
+the task of code review as well as the task of merging your changes into the
+canonical repository.
+
+A typical workflow will then consist of the following:
+
+1. Create a new local branch based off either your master or develop branch.
+2. Switch to your new local branch. (This step can be combined with the
+   previous step with the use of `git checkout -b`.)
+3. Do some work, commit, repeat as necessary.
+4. Push the local branch to your remote repository.
+5. Send a pull request.
+
+The mechanics of this process are actually quite trivial. Below, we will
+create a branch for fixing an issue in the tracker.
+
+```console
+$ git checkout -b hotfix/9295
+Switched to a new branch 'hotfix/9295'
+```
+
+... do some work ...
+
+
+```console
+$ git commit
+```
+
+... write your log message ...
+
+
+```console
+$ git push {username} hotfix/9295:hotfix/9295
+Counting objects: 38, done.
+Delta compression using up to 2 threads.
+Compression objects: 100% (18/18), done.
+Writing objects: 100% (20/20), 8.19KiB, done.
+Total 20 (delta 12), reused 0 (delta 0)
+To ssh://git@github.com/{username}/zend-component-installer.git
+   b5583aa..4f51698  HEAD -> master
+```
+
+To send a pull request, you have two options.
+
+If using GitHub, you can do the pull request from there. Navigate to
+your repository, select the branch you just created, and then select the
+"Pull Request" button in the upper right. Select the user/organization
+"zendframework" as the recipient.
+
+If using your own repository - or even if using GitHub - you can use `git
+format-patch` to create a patchset for us to apply; in fact, this is
+**recommended** for security-related patches. If you use `format-patch`, please
+send the patches as attachments to:
+
+-  zf-devteam@zend.com for patches without security implications
+-  zf-security@zend.com for security patches
+
+#### What branch to issue the pull request against?
+
+Which branch should you issue a pull request against?
+
+- For fixes against the stable release, issue the pull request against the
+  "master" branch.
+- For new features, or fixes that introduce new elements to the public API (such
+  as new public methods or properties), issue the pull request against the
+  "develop" branch.
+
+### Branch Cleanup
+
+As you might imagine, if you are a frequent contributor, you'll start to
+get a ton of branches both locally and on your remote.
+
+Once you know that your changes have been accepted to the master
+repository, we suggest doing some cleanup of these branches.
+
+-  Local branch cleanup
+
+   ```console
+   $ git branch -d <branchname>
+   ```
+
+-  Remote branch removal
+
+   ```console
+   $ git push {username} :<branchname>
+   ```
+
+## Conduct
+
+Please see our [CONDUCT.md](CONDUCT.md) to understand expected behavior when interacting with others in the project.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,12 +1,28 @@
-Copyright (c) 2015, Zend Technologies USA, Inc.
+Copyright (c) 2015-2017, Zend Technologies USA, Inc.
+
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-- Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
-- Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-- Neither the name of Zend Technologies USA, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+- Neither the name of Zend Technologies USA, Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ one or more of the following keys under the `extra.zf` configuration in their
 
 - A **config-provider** is for use with applications that utilize
   [expressive-config-manager](https://github.com/mtymek/expressive-config-manager)
+  or [zend-config-aggregator](https://github.com/zendframework/zend-config-aggregator)
   (which may or may not be Expressive applications). The class listed must be an
   invokable that returns an array of configuration, and will be injected at the
   top of:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "composer/composer": "^1.3.2",
         "malukenho/docheader": "^0.1.5",
         "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit": "^5.7.13 || ^6.0.6",
+        "phpunit/phpunit": "^6.0.7 || ^5.7.14",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -3,21 +3,21 @@
     "description": "Composer plugin for automating component registration in zend-mvc and Expressive applications",
     "type": "composer-plugin",
     "license": "BSD-3-Clause",
-    "require": {
-        "php": "^5.6 || ^7.0",
-        "composer-plugin-api": "^1.0"
-    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
         },
         "class": "Zend\\ComponentInstaller\\ComponentInstaller"
     },
+    "require": {
+        "php": "^5.6 || ^7.0",
+        "composer-plugin-api": "^1.0"
+    },
     "require-dev": {
-        "composer/composer": "^1.2.2",
-        "phpunit/phpunit": "^4.7",
-        "roave/security-advisories": "dev-master",
+        "composer/composer": "^1.3.2",
+        "malukenho/docheader": "^0.1.5",
         "mikey179/vfsStream": "^1.6",
+        "phpunit/phpunit": "^5.7.13 || ^6.0.6",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {
@@ -32,6 +32,7 @@
     },
     "scripts": {
         "check": [
+            "@license-check",
             "@cs-check",
             "@test"
         ],
@@ -39,6 +40,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+        "test-coverage": "phpunit --coverage-clover clover.xml",
+        "license-check": "vendor/bin/docheader check src/"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4f488cacc3eb23f58b3011519970d21",
+    "content-hash": "0674469ab6fa645595d1c00501d695eb",
     "packages": [],
     "packages-dev": [
         {
@@ -978,16 +978,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.13",
+            "version": "5.7.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "60ebeed87a35ea46fd7f7d8029df2d6f013ebb34"
+                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/60ebeed87a35ea46fd7f7d8029df2d6f013ebb34",
-                "reference": "60ebeed87a35ea46fd7f7d8029df2d6f013ebb34",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4906b8faf23e42612182fd212eb6f4c0f2954b57",
+                "reference": "4906b8faf23e42612182fd212eb6f4c0f2954b57",
                 "shasum": ""
             },
             "require": {
@@ -1011,7 +1011,7 @@
                 "sebastian/global-state": "^1.1",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0|~2.0",
+                "sebastian/version": "~1.0.3|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
             "conflict": {
@@ -1056,7 +1056,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-10T09:05:10+00:00"
+            "time": "2017-02-19T07:22:16+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1495,16 +1495,16 @@
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
-                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
                 "shasum": ""
             },
             "require": {
@@ -1537,7 +1537,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-11-19T07:35:10+00:00"
+            "time": "2017-02-18T15:18:39+00:00"
         },
         {
             "name": "sebastian/recursion-context",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "719bd3693c24093b65d8e5a52571101f",
-    "content-hash": "fa43c1dcf7f20677bf23df1f19a8e7b7",
+    "content-hash": "c4f488cacc3eb23f58b3011519970d21",
     "packages": [],
     "packages-dev": [
         {
@@ -64,36 +63,36 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2016-11-02 18:11:27"
+            "time": "2016-11-02T18:11:27+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "1.2.4",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0"
+                "reference": "e7569edb4a5eadcbb2e4ad5ed753282260f281df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0",
-                "reference": "7895e4a7e0e05b06e0ebfae96fc154c6a2ba75f0",
+                "url": "https://api.github.com/repos/composer/composer/zipball/e7569edb4a5eadcbb2e4ad5ed753282260f281df",
+                "reference": "e7569edb4a5eadcbb2e4ad5ed753282260f281df",
                 "shasum": ""
             },
             "require": {
                 "composer/ca-bundle": "^1.0",
                 "composer/semver": "^1.0",
                 "composer/spdx-licenses": "^1.0",
-                "justinrainbow/json-schema": "^1.6 || ^2.0",
+                "justinrainbow/json-schema": "^1.6 || ^2.0 || ^3.0 || ^4.0",
                 "php": "^5.3.2 || ^7.0",
                 "psr/log": "^1.0",
                 "seld/cli-prompt": "^1.0",
                 "seld/jsonlint": "^1.4",
                 "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.5 || ^3.0",
-                "symfony/filesystem": "^2.5 || ^3.0",
-                "symfony/finder": "^2.2 || ^3.0",
-                "symfony/process": "^2.1 || ^3.0"
+                "symfony/console": "^2.7 || ^3.0",
+                "symfony/filesystem": "^2.7 || ^3.0",
+                "symfony/finder": "^2.7 || ^3.0",
+                "symfony/process": "^2.7 || ^3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.5 || ^5.0.5",
@@ -110,7 +109,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -141,7 +140,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2016-12-06 21:00:51"
+            "time": "2017-01-27T17:23:42+00:00"
         },
         {
             "name": "composer/semver",
@@ -203,7 +202,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30 16:08:34"
+            "time": "2016-08-30T16:08:34+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -264,7 +263,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2016-09-28 07:17:45"
+            "time": "2016-09-28T07:17:45+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -318,20 +317,20 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "2.0.5",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "6b2a33e6a768f96bdc2ead5600af0822eed17d67"
+                "reference": "d39c56a46b3ebe1f3696479966cd2b9f50aaa24f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/6b2a33e6a768f96bdc2ead5600af0822eed17d67",
-                "reference": "6b2a33e6a768f96bdc2ead5600af0822eed17d67",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/d39c56a46b3ebe1f3696479966cd2b9f50aaa24f",
+                "reference": "d39c56a46b3ebe1f3696479966cd2b9f50aaa24f",
                 "shasum": ""
             },
             "require": {
@@ -348,7 +347,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -384,7 +383,57 @@
                 "json",
                 "schema"
             ],
-            "time": "2016-06-02 10:59:52"
+            "time": "2016-12-22T16:43:46+00:00"
+        },
+        {
+            "name": "malukenho/docheader",
+            "version": "0.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/malukenho/docheader.git",
+                "reference": "f35ada934d1de3f5ba09970a6541009a41347658"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/malukenho/docheader/zipball/f35ada934d1de3f5ba09970a6541009a41347658",
+                "reference": "f35ada934d1de3f5ba09970a6541009a41347658",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|^7.0",
+                "symfony/console": "~2.0|^3.0",
+                "symfony/finder": "~2.0|^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.7"
+            },
+            "bin": [
+                "bin/docheader"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DocHeader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jefersson Nathan",
+                    "email": "malukenho@phpse.net"
+                }
+            ],
+            "description": "A small library to check header docs",
+            "homepage": "https://github.com/malukenho/docheader",
+            "keywords": [
+                "Code style",
+                "code standard",
+                "license"
+            ],
+            "time": "2016-11-17T16:46:05+00:00"
         },
         {
             "name": "mikey179/vfsStream",
@@ -430,7 +479,49 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2016-07-18 14:02:57"
+            "time": "2016-07-18T14:02:57+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-01-26T22:05:40+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -484,7 +575,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -529,7 +620,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -576,7 +667,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -639,43 +730,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
+                "reference": "c19cfc7cbb0e9338d8c469c7eedecc2a428b0971",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": "^5.6 || ^7.0",
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
             },
             "require-dev": {
                 "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
+                "ext-xdebug": ">=2.4.0",
                 "ext-xmlwriter": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -701,7 +793,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2017-01-20T15:06:43+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -748,7 +840,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -789,7 +881,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -833,7 +925,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -882,44 +974,54 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.31",
+            "version": "5.7.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3"
+                "reference": "60ebeed87a35ea46fd7f7d8029df2d6f013ebb34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
-                "reference": "98b2b39a520766bec663ff5b7ff1b729db9dbfe3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/60ebeed87a35ea46fd7f7d8029df2d6f013ebb34",
+                "reference": "60ebeed87a35ea46fd7f7d8029df2d6f013ebb34",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
                 "symfony/yaml": "~2.1|~3.0"
             },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -928,7 +1030,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -954,30 +1056,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-09 02:45:31"
+            "time": "2017-02-10T09:05:10+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -985,7 +1090,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -1010,7 +1115,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2016-12-08T20:27:08+00:00"
         },
         {
             "name": "psr/log",
@@ -1057,151 +1162,65 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
-            "name": "roave/security-advisories",
-            "version": "dev-master",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "7f0d17c75373fa03b7425e7d8bb141a814d814ab"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/7f0d17c75373fa03b7425e7d8bb141a814d814ab",
-                "reference": "7f0d17c75373fa03b7425e7d8bb141a814d814ab",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
                 "shasum": ""
             },
-            "conflict": {
-                "adodb/adodb-php": "<5.20.6",
-                "amphp/artax": ">=2,<2.0.4|>0.7.1,<1.0.4",
-                "aws/aws-sdk-php": ">=3,<3.2.1",
-                "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
-                "cakephp/cakephp": ">=3,<3.0.15|>=2,<2.4.99|>=2.5,<2.5.99|>=2.6,<2.6.12|>=1.3,<1.3.18|>=2.7,<2.7.6|>=3.1,<3.1.4",
-                "cartalyst/sentry": "<2.1",
-                "codeigniter/framework": "<=3.0.6",
-                "composer/composer": "<=1.0.0-alpha11",
-                "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/core": ">=2.11,<3.5.15",
-                "doctrine/annotations": ">=1,<1.2.7",
-                "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
-                "doctrine/common": ">=2,<2.4.3|>=2.5,<2.5.1",
-                "doctrine/dbal": ">=2,<2.0.8|>=2.1,<2.1.2",
-                "doctrine/doctrine-bundle": "<1.5.2",
-                "doctrine/doctrine-module": "<=0.7.1",
-                "doctrine/mongodb-odm": ">=1,<1.0.2",
-                "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
-                "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1",
-                "dompdf/dompdf": ">=0.6,<0.6.2",
-                "drupal/core": ">=8,<8.2.3",
-                "drupal/drupal": ">=8,<8.2.3",
-                "firebase/php-jwt": "<2",
-                "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
-                "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
-                "gregwar/rst": "<1.0.3",
-                "guzzlehttp/guzzle": ">=6,<6.2.1|>=4.0.0-rc2,<4.2.4|>=5,<5.3.1",
-                "illuminate/auth": ">=4,<4.0.99|>=4.1,<4.1.26",
-                "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
-                "joomla/session": "<1.3.1",
-                "laravel/framework": ">=4,<4.0.99|>=4.1,<4.1.29",
-                "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
-                "magento/magento2ce": ">=2,<2.2",
-                "monolog/monolog": ">=1.8,<1.12",
-                "namshi/jose": "<2.2",
-                "oro/crm": ">=1.7,<1.7.4",
-                "oro/platform": ">=1.7,<1.7.4",
-                "phpmailer/phpmailer": ">=5,<5.2.14",
-                "pusher/pusher-php-server": "<2.2.1",
-                "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
-                "shopware/shopware": "<4.3.7|>=5,<5.1.5",
-                "silverstripe/cms": ">=3.1,<3.1.11|>=3,<=3.0.11",
-                "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": ">=3,<3.3",
-                "silverstripe/userforms": "<3",
-                "simplesamlphp/saml2": ">=1.9,<1.9.1|>=1.10,<1.10.3|>=2.3,<2.3.3",
-                "simplesamlphp/simplesamlphp": "<1.14.11",
-                "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
-                "socalnick/scn-social-auth": "<1.15.2",
-                "swiftmailer/swiftmailer": ">=4,<4.99.99|>=5,<5.2.1",
-                "symfony/dependency-injection": ">=2,<2.0.17",
-                "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.7",
-                "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
-                "symfony/http-foundation": ">=2,<2.3.27|>=2.4,<2.5.11|>=2.6,<2.6.6",
-                "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
-                "symfony/routing": ">=2,<2.0.19",
-                "symfony/security": ">=2.3,<2.3.37|>=2.4,<2.6.13|>=2.7,<2.7.9|>=2,<2.0.25|>=2.1,<2.1.13|>=2.2,<2.2.9",
-                "symfony/security-core": ">=2.8,<2.8.6|>=3,<3.0.6|>=2.4,<2.6.13|>=2.7,<2.7.9",
-                "symfony/security-http": ">=2.4,<2.7.13|>=2.3,<2.3.41|>=2.8,<2.8.6|>=3,<3.0.6",
-                "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.3.41|>=2.4,<2.7.13|>=2.8,<2.8.6|>=3,<3.0.6",
-                "symfony/translation": ">=2,<2.0.17",
-                "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
-                "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
-                "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
-                "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
-                "twig/twig": "<1.20",
-                "typo3/cms": ">=6.2,<6.2.29|>=8,<8.4.1|>=7,<7.6.13",
-                "typo3/flow": ">=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5|>=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1",
-                "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
-                "willdurand/js-translation-bundle": "<2.1.1",
-                "yiisoft/yii": ">=1.1.14,<1.1.15",
-                "yiisoft/yii2": "<2.0.5",
-                "yiisoft/yii2-bootstrap": "<2.0.4",
-                "yiisoft/yii2-dev": "<2.0.4",
-                "yiisoft/yii2-gii": "<2.0.4",
-                "yiisoft/yii2-jui": "<2.0.4",
-                "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
-                "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
-                "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
-                "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
-                "zendframework/zend-diactoros": ">=1,<1.0.4",
-                "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-http": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.3,<2.3.8|>=2.4,<2.4.1",
-                "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-                "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
-                "zendframework/zend-mail": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.3,<2.3.8|>=2.4,<2.4.1",
-                "zendframework/zend-navigation": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-session": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.9|>=2.3,<2.3.4",
-                "zendframework/zend-validator": ">=2.3,<2.3.6",
-                "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-                "zendframework/zendframework": ">=2,<2.4.9|>=2.5,<2.5.1",
-                "zendframework/zendframework1": "<1.12.20",
-                "zendframework/zendopenid": ">=2,<2.0.2",
-                "zendframework/zendxml": ">=1,<1.0.1",
-                "zf-commons/zfc-user": "<1.2.2",
-                "zfcampus/zf-apigility-doctrine": ">=1,<1.0.3",
-                "zfr/zfr-oauth2-server-module": "<0.1.2"
+            "require": {
+                "php": ">=5.6"
             },
-            "type": "metapackage",
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "role": "maintainer"
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2016-12-19 13:03:54"
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13T06:45:14+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.2",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
-                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
                 "shasum": ""
             },
             "require": {
@@ -1252,7 +1271,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2016-11-19 09:18:40"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1304,32 +1323,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1354,25 +1373,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -1381,7 +1400,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1421,7 +1440,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1472,20 +1491,66 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "reference": "96f8a3f257b69e8128ad74d3a7fd464bcbaa3b35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-11-19T07:35:10+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -1497,7 +1562,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1525,23 +1590,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1560,7 +1675,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "seld/cli-prompt",
@@ -1608,7 +1723,7 @@
                 "input",
                 "prompt"
             ],
-            "time": "2016-04-18 09:31:41"
+            "time": "2016-04-18T09:31:41+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -1654,7 +1769,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2016-11-14 17:59:58"
+            "time": "2016-11-14T17:59:58+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -1698,20 +1813,20 @@
             "keywords": [
                 "phra"
             ],
-            "time": "2015-10-13 18:44:15"
+            "time": "2015-10-13T18:44:15+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f"
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9b324f3a1132459a7274a0ace2e1b766ba80930f",
-                "reference": "9b324f3a1132459a7274a0ace2e1b766ba80930f",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/86dd55a522238211f9f3631e3361703578941d9a",
+                "reference": "86dd55a522238211f9f3631e3361703578941d9a",
                 "shasum": ""
             },
             "require": {
@@ -1776,20 +1891,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-11-30 04:02:31"
+            "time": "2017-02-02T03:30:00+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.1",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d12aa9ca20f4db83ec58410978dab6afcb9d6aaa"
+                "reference": "0e5e6899f82230fcb1153bcaf0e106ffaa44b870"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d12aa9ca20f4db83ec58410978dab6afcb9d6aaa",
-                "reference": "d12aa9ca20f4db83ec58410978dab6afcb9d6aaa",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e6899f82230fcb1153bcaf0e106ffaa44b870",
+                "reference": "0e5e6899f82230fcb1153bcaf0e106ffaa44b870",
                 "shasum": ""
             },
             "require": {
@@ -1839,20 +1954,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-11 14:34:22"
+            "time": "2017-02-16T14:07:22+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.1",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "9f923e68d524a3095c5a2ae5fc7220c7cbc12231"
+                "reference": "9b98854cb45bc59d100b7d4cc4cf9e05f21026b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/9f923e68d524a3095c5a2ae5fc7220c7cbc12231",
-                "reference": "9f923e68d524a3095c5a2ae5fc7220c7cbc12231",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/9b98854cb45bc59d100b7d4cc4cf9e05f21026b9",
+                "reference": "9b98854cb45bc59d100b7d4cc4cf9e05f21026b9",
                 "shasum": ""
             },
             "require": {
@@ -1896,20 +2011,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-16 22:18:16"
+            "time": "2017-02-16T16:34:18+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.2.1",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8d4cf7561a5b17e5eb7a02b80d0b8f014a3796d4"
+                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8d4cf7561a5b17e5eb7a02b80d0b8f014a3796d4",
-                "reference": "8d4cf7561a5b17e5eb7a02b80d0b8f014a3796d4",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
+                "reference": "a0c6ef2dc78d33b58d91d3a49f49797a184d06f4",
                 "shasum": ""
             },
             "require": {
@@ -1945,20 +2060,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-24 00:46:43"
+            "time": "2017-01-08T20:47:33+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.1",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b"
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
-                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8c71141cae8e2957946b403cc71a67213c0380d6",
+                "reference": "8c71141cae8e2957946b403cc71a67213c0380d6",
                 "shasum": ""
             },
             "require": {
@@ -1994,7 +2109,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-13 09:39:43"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2053,20 +2168,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.2.1",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "02ea84847aad71be7e32056408bb19f3a616cdd3"
+                "reference": "0ab87c1e7570b3534a6e51eb4ca8e9f6d7327856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/02ea84847aad71be7e32056408bb19f3a616cdd3",
-                "reference": "02ea84847aad71be7e32056408bb19f3a616cdd3",
+                "url": "https://api.github.com/repos/symfony/process/zipball/0ab87c1e7570b3534a6e51eb4ca8e9f6d7327856",
+                "reference": "0ab87c1e7570b3534a6e51eb4ca8e9f6d7327856",
                 "shasum": ""
             },
             "require": {
@@ -2102,20 +2217,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-24 10:40:28"
+            "time": "2017-02-16T14:07:22+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.1",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
-                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
                 "shasum": ""
             },
             "require": {
@@ -2157,7 +2272,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-10 10:07:06"
+            "time": "2017-02-16T22:46:52+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2207,7 +2322,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -2236,14 +2351,12 @@
                 "Coding Standard",
                 "zf"
             ],
-            "time": "2016-11-09 21:30:43"
+            "time": "2016-11-09T21:30:43+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "roave/security-advisories": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/doc/book/index.html
+++ b/doc/book/index.html
@@ -79,7 +79,7 @@
 
       <p>
         Zend Framework modules typically deliver functionality around the
-        <a href="https://zendframework.github.io/zend-mvc/">zend-mvc</a>
+        <a href="https://docs.zendframework.com/zend-mvc/">zend-mvc</a>
         workflow, including MVC event listeners, controllers, etc.
         To enable the installer workflow, they require the following:
       </p>
@@ -137,7 +137,8 @@
 
       <p>
         Configuration providers work with
-        <a href="https://github.com/mtymek/expressive-config-manager">expressive-config-manager</a>,
+        <a href="https://github.com/mtymek/expressive-config-manager">expressive-config-manager</a>
+        and <a href="https://github.com/zendframework/zend-config-aggregator">zend-config-aggregator</a>,
         which provides generic functionality for aggregating and merging
         application configuration. Packages that provide configuration will
         provide an invokable class that returns configuration for the package.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,4 +5,4 @@ pages:
 site_name: zend-component-installer
 site_description: Zend\Component\Installer
 repo_url: 'https://github.com/zendframework/zend-component-installer'
-copyright: 'Copyright (c) 2016 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'
+copyright: 'Copyright (c) 2017 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -160,7 +160,8 @@ class Collection implements
     /**
      * Merge an array of values with the current collection.
      *
-     * @return self
+     * @param array $values
+     * @return Collection
      */
     public function merge(array $values)
     {
@@ -171,7 +172,8 @@ class Collection implements
     /**
      * Prepend a value to the collection.
      *
-     * @return self
+     * @param mixed $value
+     * @return Collection
      */
     public function prepend($value)
     {
@@ -195,6 +197,7 @@ class Collection implements
      *
      * @param string|int $offset
      * @return mixed
+     * @throws OutOfRangeException
      */
     public function offsetGet($offset)
     {

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * @link      http://github.com/zendframework/zend-component-installer for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller;

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -497,7 +497,7 @@ class ComponentInstaller implements
             "\n  <question>Please select which config file you wish to inject '%s' into:</question>\n",
             $name
         ));
-        array_push($ask, '  Make your selection (default is <comment>0</comment>):');
+        $ask[] = '  Make your selection (default is <comment>0</comment>):';
 
         while (true) {
             $answer = $this->io->ask($ask, 0);

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -228,14 +228,14 @@ class ComponentInstaller implements
                         $fullPath = sprintf('%s/%s', $packagePath, $path);
                         if (is_dir(rtrim($fullPath, '/'))) {
                             $modulePath = sprintf('%s%s', $fullPath, 'Module.php');
-                        } elseif (substr($path, -10) == 'Module.php') {
+                        } elseif (substr($path, -10) === 'Module.php') {
                             $modulePath = $fullPath;
                         } else {
                             continue 2;
                         }
                         break;
                     case 'files':
-                        if (substr($path, -10) != 'Module.php') {
+                        if (substr($path, -10) !== 'Module.php') {
                             continue 2;
                         }
                         $modulePath = sprintf('%s/%s', $packagePath, $path);

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -551,7 +551,17 @@ class ComponentInstaller implements
     private function injectModuleIntoConfig($package, $module, Injector\InjectorInterface $injector, $packageType)
     {
         $this->io->write(sprintf('<info>Installing %s from package %s</info>', $module, $package));
-        $injector->inject($module, $packageType, $this->io);
+
+        try {
+            if (! $injector->inject($module, $packageType)) {
+                $this->io->write('<info>    Package is already registered; skipping</info>');
+            }
+        } catch (Exception\RuntimeException $ex) {
+            $this->io->write(sprintf(
+                '<error>    %s</error>',
+                $ex->getMessage()
+            ));
+        }
     }
 
     /**
@@ -600,7 +610,13 @@ class ComponentInstaller implements
     {
         $injectors->each(function ($injector) use ($module, $package) {
             $this->io->write(sprintf('<info>Removing %s from package %s</info>', $module, $package));
-            $injector->remove($module, $this->io);
+
+            if ($injector->remove($module)) {
+                $this->io->write(sprintf(
+                    '<info>    Removed package from %s</info>',
+                    $injector->getConfigFile()
+                ));
+            }
         });
     }
 

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -612,7 +612,7 @@ class ComponentInstaller implements
      */
     private function moduleIsValid($module)
     {
-        return (is_string($module) && ! empty($module));
+        return is_string($module) && ! empty($module);
     }
 
     /**

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -76,7 +76,7 @@ class ComponentInstaller implements
     /**
      * Map of known package types to composer config keys.
      *
-     * @param array
+     * @var string[]
      */
     private $packageTypes = [
         Injector\InjectorInterface::TYPE_CONFIG_PROVIDER => 'config-provider',
@@ -125,7 +125,7 @@ class ComponentInstaller implements
     /**
      * Return list of event handlers in this class.
      *
-     * @return array
+     * @return string[]
      */
     public static function getSubscribedEvents()
     {
@@ -456,7 +456,7 @@ class ComponentInstaller implements
      * Prepare a list of modules to install/register with configuration.
      *
      * @param string[] $extra
-     * @param ConfigOption[] $options
+     * @param Collection $options
      * @return string[] List of packages to install
      */
     private function marshalInstallableModules(array $extra, Collection $options)

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2015 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller;

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller;

--- a/src/ConfigDiscovery.php
+++ b/src/ConfigDiscovery.php
@@ -99,7 +99,7 @@ class ConfigDiscovery
                 $discovered[] = new ConfigOption($file, $injector);
             });
 
-        return (1 === $discovered->count())
+        return 1 === $discovered->count()
             ? new Collection([])
             : $discovered;
     }

--- a/src/ConfigDiscovery/AbstractDiscovery.php
+++ b/src/ConfigDiscovery/AbstractDiscovery.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/ApplicationConfig.php
+++ b/src/ConfigDiscovery/ApplicationConfig.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/ConfigAggregator.php
+++ b/src/ConfigDiscovery/ConfigAggregator.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/DevelopmentConfig.php
+++ b/src/ConfigDiscovery/DevelopmentConfig.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/DevelopmentWorkConfig.php
+++ b/src/ConfigDiscovery/DevelopmentWorkConfig.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/DiscoveryChain.php
+++ b/src/ConfigDiscovery/DiscoveryChain.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/DiscoveryChainInterface.php
+++ b/src/ConfigDiscovery/DiscoveryChainInterface.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/DiscoveryChainInterface.php
+++ b/src/ConfigDiscovery/DiscoveryChainInterface.php
@@ -12,6 +12,7 @@ interface DiscoveryChainInterface
     /**
      * Determine if discovery exists
      *
+     * @param string $name
      * @return bool
      */
     public function discoveryExists($name);

--- a/src/ConfigDiscovery/DiscoveryInterface.php
+++ b/src/ConfigDiscovery/DiscoveryInterface.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/ExpressiveConfig.php
+++ b/src/ConfigDiscovery/ExpressiveConfig.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigDiscovery/ModulesConfig.php
+++ b/src/ConfigDiscovery/ModulesConfig.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\ConfigDiscovery;

--- a/src/ConfigOption.php
+++ b/src/ConfigOption.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller;

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\ComponentInstaller\Exception;
+
+class RuntimeException extends \RuntimeException
+{
+}

--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -7,7 +7,7 @@
 
 namespace Zend\ComponentInstaller\Injector;
 
-use Composer\IO\IOInterface;
+use Zend\ComponentInstaller\Exception;
 
 abstract class AbstractInjector implements InjectorInterface
 {
@@ -159,26 +159,24 @@ abstract class AbstractInjector implements InjectorInterface
     /**
      * {@inheritDoc}
      */
-    public function inject($package, $type, IOInterface $io)
+    public function inject($package, $type)
     {
         $config = file_get_contents($this->configFile);
 
         if ($this->isRegisteredInConfig($package, $config)) {
-            $io->write(sprintf('<info>    Package is already registered; skipping</info>'));
-            return;
+            return false;
         }
 
-        if ($type == self::TYPE_COMPONENT
+        if ($type === self::TYPE_COMPONENT
             && $this->moduleDependencies
-            && $this->injectAfterDependencies($package, $config, $io)
         ) {
-            return;
+            return $this->injectAfterDependencies($package, $config);
         }
 
-        if ($type == self::TYPE_MODULE
-            && $this->injectBeforeApplicationModules($package, $config, $io)
+        if ($type === self::TYPE_MODULE
+            && ($firstApplicationModule = $this->findFirstEnabledApplicationModule($this->applicationModules, $config))
         ) {
-            return;
+            return $this->injectBeforeApplicationModules($package, $config, $firstApplicationModule);
         }
 
         $pattern = $this->injectionPatterns[$type]['pattern'];
@@ -189,29 +187,29 @@ abstract class AbstractInjector implements InjectorInterface
 
         $config = preg_replace($pattern, $replacement, $config);
         file_put_contents($this->configFile, $config);
+
+        return true;
     }
 
     /**
-     * Inject component $package after all dependencies into $config and return true.
-     * If any of dependencies is not registered the method will write error to $io
-     * and will also return true, to prevent injecting this package later.
-     * Method return false only in case when dependencies for the package are not found.
+     * Injects component $package after all dependencies
+     * into $config and returns true.
+     * If any of dependencies is not registered the method
+     * throws RuntimeException.
      *
      * @param string $package
      * @param string $config
-     * @param IOInterface $io
-     * @return bool
+     * @return true
+     * @throws Exception\RuntimeException
      */
-    private function injectAfterDependencies($package, $config, IOInterface $io)
+    private function injectAfterDependencies($package, $config)
     {
         foreach ($this->moduleDependencies as $dependency) {
             if (! $this->isRegisteredInConfig($dependency, $config)) {
-                $io->write(sprintf(
-                    '<error>    Dependency %s is not registered in the configuration</error>',
+                throw new Exception\RuntimeException(sprintf(
+                    'Dependency %s is not registered in the configuration',
                     $dependency
                 ));
-
-                return true;
             }
         }
 
@@ -267,28 +265,24 @@ abstract class AbstractInjector implements InjectorInterface
      *
      * @param string $package
      * @param string $config
-     * @param IOInterface $io
+     * @param string $firstApplicationModule
      * @return bool
      */
-    private function injectBeforeApplicationModules($package, $config, IOInterface $io)
+    private function injectBeforeApplicationModules($package, $config, $firstApplicationModule)
     {
-        if ($firstApplicationModule = $this->findFirstEnabledApplicationModule($this->applicationModules, $config)) {
-            $pattern = sprintf(
-                $this->injectionPatterns[self::TYPE_BEFORE_APPLICATION]['pattern'],
-                preg_quote($firstApplicationModule, '/')
-            );
-            $replacement = sprintf(
-                $this->injectionPatterns[self::TYPE_BEFORE_APPLICATION]['replacement'],
-                $package
-            );
+        $pattern = sprintf(
+            $this->injectionPatterns[self::TYPE_BEFORE_APPLICATION]['pattern'],
+            preg_quote($firstApplicationModule, '/')
+        );
+        $replacement = sprintf(
+            $this->injectionPatterns[self::TYPE_BEFORE_APPLICATION]['replacement'],
+            $package
+        );
 
-            $config = preg_replace($pattern, $replacement, $config);
-            file_put_contents($this->configFile, $config);
+        $config = preg_replace($pattern, $replacement, $config);
+        file_put_contents($this->configFile, $config);
 
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**
@@ -341,18 +335,19 @@ abstract class AbstractInjector implements InjectorInterface
     }
 
     /**
-     * Remove a package from the configuration.
+     * Removes a package from the configuration.
+     * Returns true if successfully removed,
+     * false when package is not registered.
      *
      * @param string $package Package name.
-     * @param IOInterface $io
-     * @return void
+     * @return bool
      */
-    public function remove($package, IOInterface $io)
+    public function remove($package)
     {
         $config = file_get_contents($this->configFile);
 
-        if (! $this->isRegistered($package, $config)) {
-            return;
+        if (! $this->isRegisteredInConfig($package, $config)) {
+            return false;
         }
 
         $config = preg_replace(
@@ -369,7 +364,17 @@ abstract class AbstractInjector implements InjectorInterface
 
         file_put_contents($this->configFile, $config);
 
-        $io->write(sprintf('<info>    Removed package from %s</info>', $this->configFile));
+        return true;
+    }
+
+    /**
+     * Returns config file name of the injector.
+     *
+     * @return string
+     */
+    public function getConfigFile()
+    {
+        return $this->configFile;
     }
 
     /**

--- a/src/Injector/AbstractInjector.php
+++ b/src/Injector/AbstractInjector.php
@@ -241,7 +241,7 @@ abstract class AbstractInjector implements InjectorInterface
      */
     private function findLastDependency(array $dependencies, $config)
     {
-        if (count($dependencies) == 1) {
+        if (count($dependencies) === 1) {
             return reset($dependencies);
         }
 

--- a/src/Injector/ApplicationConfigInjector.php
+++ b/src/Injector/ApplicationConfigInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/ConditionalDiscoveryTrait.php
+++ b/src/Injector/ConditionalDiscoveryTrait.php
@@ -1,12 +1,11 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;
-
-use Composer\IO\IOInterface;
 
 trait ConditionalDiscoveryTrait
 {
@@ -16,13 +15,13 @@ trait ConditionalDiscoveryTrait
      * Prepends the package with a `\\` in order to ensure it is fully
      * qualified, preventing issues in config files that are namespaced.
      */
-    public function inject($package, $type, IOInterface $io)
+    public function inject($package, $type)
     {
         if (! $this->validConfigAggregatorConfig()) {
-            return;
+            return false;
         }
 
-        parent::inject('\\' . $package, $type, $io);
+        return parent::inject('\\' . $package, $type);
     }
 
     /**
@@ -31,13 +30,13 @@ trait ConditionalDiscoveryTrait
      * Prepends the package with a `\\` in order to ensure it is fully
      * qualified, preventing issues in config files that are namespaced.
      */
-    public function remove($package, IOInterface $io)
+    public function remove($package)
     {
         if (! $this->validConfigAggregatorConfig()) {
-            return;
+            return false;
         }
 
-        parent::remove('\\' . $package, $io);
+        return parent::remove('\\' . $package);
     }
 
     /**

--- a/src/Injector/ConfigAggregatorInjector.php
+++ b/src/Injector/ConfigAggregatorInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -97,7 +97,7 @@ class ConfigInjectorChain implements InjectorInterface
                 return $injector->isRegistered($package);
             })
             ->count();
-        return $this->chain->count() == $isRegisteredCount;
+        return $this->chain->count() === $isRegisteredCount;
     }
 
     /**

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -7,7 +7,6 @@
 
 namespace Zend\ComponentInstaller\Injector;
 
-use Composer\IO\IOInterface;
 use Zend\ComponentInstaller\Collection;
 use Zend\ComponentInstaller\ConfigDiscovery\DiscoveryChainInterface;
 
@@ -27,7 +26,7 @@ class ConfigInjectorChain implements InjectorInterface
      *
      * @param int[]
      */
-    protected $allowedTypes = null;
+    protected $allowedTypes;
 
     /**
      * Constructor
@@ -76,7 +75,7 @@ class ConfigInjectorChain implements InjectorInterface
      */
     public function getTypesAllowed()
     {
-        if (isset($this->allowedTypes)) {
+        if ($this->allowedTypes) {
             return $this->allowedTypes;
         }
         $allowedTypes = [];
@@ -103,23 +102,31 @@ class ConfigInjectorChain implements InjectorInterface
     /**
      * {@inheritDoc}
      */
-    public function inject($package, $type, IOInterface $io)
+    public function inject($package, $type)
     {
+        $injected = false;
+
         $this->chain
-            ->each(function ($injector) use ($package, $type, $io) {
-                $injector->inject($package, $type, $io);
+            ->each(function ($injector) use ($package, $type, &$injected) {
+                $injected = $injector->inject($package, $type) || $injected;
             });
+
+        return $injected;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function remove($package, IOInterface $io)
+    public function remove($package)
     {
+        $removed = false;
+
         $this->chain
-            ->each(function ($injector) use ($package, $io) {
-                $injector->remove($package, $io);
+            ->each(function ($injector) use ($package, &$removed) {
+                $removed = $injector->remove($package) || $removed;
             });
+
+        return $removed;
     }
 
     /**

--- a/src/Injector/ConfigInjectorChain.php
+++ b/src/Injector/ConfigInjectorChain.php
@@ -14,7 +14,7 @@ use Zend\ComponentInstaller\ConfigDiscovery\DiscoveryChainInterface;
 class ConfigInjectorChain implements InjectorInterface
 {
     /**
-     * ConfigIngectors Collection
+     * ConfigInjectors Collection
      *
      * @var Collection
      */

--- a/src/Injector/DevelopmentConfigInjector.php
+++ b/src/Injector/DevelopmentConfigInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/DevelopmentWorkConfigInjector.php
+++ b/src/Injector/DevelopmentWorkConfigInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/ExpressiveConfigInjector.php
+++ b/src/Injector/ExpressiveConfigInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/InjectorInterface.php
+++ b/src/Injector/InjectorInterface.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/InjectorInterface.php
+++ b/src/Injector/InjectorInterface.php
@@ -7,7 +7,7 @@
 
 namespace Zend\ComponentInstaller\Injector;
 
-use Composer\IO\IOInterface;
+use Zend\ComponentInstaller\Exception;
 
 interface InjectorInterface
 {
@@ -45,19 +45,19 @@ interface InjectorInterface
      *
      * @param string $package Package to inject into configuration.
      * @param int $type One of the TYPE_* constants.
-     * @param IOInterface $io
-     * @return void
+     * @return bool
+     * @throws Exception\RuntimeException
      */
-    public function inject($package, $type, IOInterface $io);
+    public function inject($package, $type);
 
     /**
      * Remove a package from the configuration.
      *
      * @param string $package Package to remove.
-     * @param IOInterface $io
-     * @return void
+     * @return bool
+     * @throws Exception\RuntimeException
      */
-    public function remove($package, IOInterface $io);
+    public function remove($package);
 
     /**
      * Set modules of the application.

--- a/src/Injector/ModulesConfigInjector.php
+++ b/src/Injector/ModulesConfigInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/ModulesConfigInjector.php
+++ b/src/Injector/ModulesConfigInjector.php
@@ -19,7 +19,7 @@ class ModulesConfigInjector extends AbstractInjector
     /**
      * Patterns and replacements to use when registering a code item.
      *
-     * @var string[]
+     * @var array[]
      */
     protected $injectionPatterns = [
         self::TYPE_COMPONENT => [

--- a/src/Injector/NoopInjector.php
+++ b/src/Injector/NoopInjector.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\ComponentInstaller\Injector;

--- a/src/Injector/NoopInjector.php
+++ b/src/Injector/NoopInjector.php
@@ -7,8 +7,6 @@
 
 namespace Zend\ComponentInstaller\Injector;
 
-use Composer\IO\IOInterface;
-
 class NoopInjector implements InjectorInterface
 {
     /**
@@ -41,15 +39,17 @@ class NoopInjector implements InjectorInterface
     /**
      * {@inheritDoc}
      */
-    public function inject($package, $type, IOInterface $io)
+    public function inject($package, $type)
     {
+        return false;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function remove($package, IOInterface $io)
+    public function remove($package)
     {
+        return false;
     }
 
     /**

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -15,7 +15,7 @@ use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Zend\ComponentInstaller\ComponentInstaller;

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -17,7 +17,7 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
-use Prophecy\Prophecy\ProphecyInterface;
+use Prophecy\Prophecy\ObjectProphecy;
 use Zend\ComponentInstaller\ComponentInstaller;
 
 class ComponentInstallerTest extends TestCase
@@ -28,22 +28,22 @@ class ComponentInstallerTest extends TestCase
     private $projectRoot;
 
     /**
-     * @var ProphecyInterface|ComponentInstaller
+     * @var ComponentInstaller|ObjectProphecy
      */
     private $installer;
 
     /**
-     * @var ProphecyInterface|Composer
+     * @var Composer|ObjectProphecy
      */
     private $composer;
 
     /**
-     * @var ProphecyInterface|IOInterface
+     * @var IOInterface|ObjectProphecy
      */
     private $io;
 
     /**
-     * @var ProphecyInterface|InstallationManager
+     * @var InstallationManager|ObjectProphecy
      */
     private $installationManager;
 
@@ -104,7 +104,7 @@ class Module {
 CONTENT
         );
 
-        /** @var ProphecyInterface|PackageInterface $package */
+        /** @var PackageInterface|ObjectProphecy $package */
         $package = $this->prophesize(PackageInterface::class);
         $package->getName()->willReturn('some/component');
         $package->getExtra()->willReturn([
@@ -477,7 +477,7 @@ class Module {
 CONTENT
         );
 
-        /** @var ProphecyInterface|PackageInterface $package */
+        /** @var PackageInterface|ObjectProphecy $package */
         $package = $this->prophesize(PackageInterface::class);
         $package->getName()->willReturn('some/component');
         $package->getExtra()->willReturn([
@@ -605,7 +605,7 @@ CONTENT
             '<' . "?php\nreturn [\n    'modules' => [" . $modules . "\n    ],\n];"
         );
 
-        /** @var ProphecyInterface|PackageInterface $package */
+        /** @var PackageInterface|ObjectProphecy $package */
         $package = $this->prophesize(PackageInterface::class);
         $package->getName()->willReturn('some/module');
         $package->getExtra()->willReturn([

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -133,15 +133,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'SomeComponent' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'SomeComponent' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -152,7 +155,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -504,19 +507,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr(
+            if (false === strpos(
                 $argument[0],
                 sprintf("Please select which config file you wish to inject '%s' into", $packageName)
-            )
-            ) {
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -527,7 +529,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -627,15 +629,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'SomeModule' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'SomeModule' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -646,7 +651,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -783,15 +788,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Component' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -802,7 +810,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -844,35 +852,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Component' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 0)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Other\Component' into")) {
-                return false;
-            }
-
-            if (! strstr($argument[1], 'Do not inject')) {
-                return false;
-            }
-
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -883,7 +874,30 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Other\Component' into"
+            )) {
+                return false;
+            }
+
+            if (false === strpos($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (false === strpos($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -928,15 +942,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Component' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -947,7 +964,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -982,15 +999,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Other\Component' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Other\Component' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -1001,7 +1021,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -1041,15 +1061,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Component' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -1060,7 +1083,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -1227,15 +1250,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Module' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Module' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -1246,7 +1272,7 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -1292,35 +1318,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Module' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Module' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 0)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
-                return false;
-            }
-
-            if (! strstr($argument[1], 'Do not inject')) {
-                return false;
-            }
-
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -1331,7 +1340,30 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Component' into"
+            )) {
+                return false;
+            }
+
+            if (false === strpos($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (false === strpos($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
@@ -1382,35 +1414,18 @@ CONTENT
                 return false;
             }
 
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Module' into")) {
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Module' into"
+            )) {
                 return false;
             }
 
-            if (! strstr($argument[1], 'Do not inject')) {
+            if (false === strpos($argument[1], 'Do not inject')) {
                 return false;
             }
 
-            if (! strstr($argument[2], 'application.config.php')) {
-                return false;
-            }
-
-            return true;
-        }), 0)->willReturn(1);
-
-        $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-
-            if (! strstr($argument[0], "Please select which config file you wish to inject 'Some\Component' into")) {
-                return false;
-            }
-
-            if (! strstr($argument[1], 'Do not inject')) {
-                return false;
-            }
-
-            if (! strstr($argument[2], 'application.config.php')) {
+            if (false === strpos($argument[2], 'application.config.php')) {
                 return false;
             }
 
@@ -1421,7 +1436,30 @@ CONTENT
             if (! is_array($argument)) {
                 return false;
             }
-            if (! strstr($argument[0], 'Remember')) {
+
+            if (false === strpos(
+                $argument[0],
+                "Please select which config file you wish to inject 'Some\Component' into"
+            )) {
+                return false;
+            }
+
+            if (false === strpos($argument[1], 'Do not inject')) {
+                return false;
+            }
+
+            if (false === strpos($argument[2], 'application.config.php')) {
+                return false;
+            }
+
+            return true;
+        }), 0)->willReturn(1);
+
+        $this->io->ask(Argument::that(function ($argument) {
+            if (! is_array($argument)) {
+                return false;
+            }
+            if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2015 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller;

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -540,7 +540,7 @@ CONTENT
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
 
-        $config = include(vfsStream::url('project/config/application.config.php'));
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals($result, $modules);
     }
@@ -659,7 +659,7 @@ CONTENT
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
 
-        $config = include(vfsStream::url('project/config/application.config.php'));
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals($result, $modules);
     }
@@ -1258,7 +1258,7 @@ CONTENT
         }))->shouldBeCalled();
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config = include(vfsStream::url('project/config/application.config.php'));
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Some\Component',
@@ -1347,7 +1347,7 @@ CONTENT
         }))->shouldBeCalled();
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config = include(vfsStream::url('project/config/application.config.php'));
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Some\Component',
@@ -1437,7 +1437,7 @@ CONTENT
         }))->shouldBeCalled();
 
         $this->assertNull($this->installer->onPostPackageInstall($event->reveal()));
-        $config = include(vfsStream::url('project/config/application.config.php'));
+        $config = include vfsStream::url('project/config/application.config.php');
         $modules = $config['modules'];
         $this->assertEquals([
             'Some\Component',

--- a/test/ConfigDiscovery/ApplicationConfigTest.php
+++ b/test/ConfigDiscovery/ApplicationConfigTest.php
@@ -14,8 +14,10 @@ use Zend\ComponentInstaller\ConfigDiscovery\ApplicationConfig;
 
 class ApplicationConfigTest extends TestCase
 {
+    /** @var vfsStreamDirectory */
     private $configDir;
 
+    /** @var ApplicationConfig */
     private $locator;
 
     public function setUp()
@@ -49,6 +51,8 @@ class ApplicationConfigTest extends TestCase
 
     /**
      * @dataProvider validApplicationConfigContents
+     *
+     * @param string $contents
      */
     public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
     {

--- a/test/ConfigDiscovery/ApplicationConfigTest.php
+++ b/test/ConfigDiscovery/ApplicationConfigTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\ConfigDiscovery;

--- a/test/ConfigDiscovery/ApplicationConfigTest.php
+++ b/test/ConfigDiscovery/ApplicationConfigTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ComponentInstaller\ConfigDiscovery;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ComponentInstaller\ConfigDiscovery\ApplicationConfig;
 
 class ApplicationConfigTest extends TestCase

--- a/test/ConfigDiscovery/ConfigAggregatorTest.php
+++ b/test/ConfigDiscovery/ConfigAggregatorTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ComponentInstaller\ConfigDiscovery;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ComponentInstaller\ConfigDiscovery\ConfigAggregator;
 
 class ConfigAggregatorTest extends TestCase

--- a/test/ConfigDiscovery/ConfigAggregatorTest.php
+++ b/test/ConfigDiscovery/ConfigAggregatorTest.php
@@ -14,8 +14,10 @@ use Zend\ComponentInstaller\ConfigDiscovery\ConfigAggregator;
 
 class ConfigAggregatorTest extends TestCase
 {
+    /** @var vfsStreamDirectory */
     private $configDir;
 
+    /** @var ConfigAggregator */
     private $locator;
 
     public function setUp()
@@ -55,6 +57,8 @@ class ConfigAggregatorTest extends TestCase
 
     /**
      * @dataProvider validExpressiveConfigContents
+     *
+     * @param string $contents
      */
     public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
     {

--- a/test/ConfigDiscovery/ConfigAggregatorTest.php
+++ b/test/ConfigDiscovery/ConfigAggregatorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\ConfigDiscovery;

--- a/test/ConfigDiscovery/DevelopmentConfigTest.php
+++ b/test/ConfigDiscovery/DevelopmentConfigTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ComponentInstaller\ConfigDiscovery;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ComponentInstaller\ConfigDiscovery\DevelopmentConfig;
 
 class DevelopmentConfigTest extends TestCase

--- a/test/ConfigDiscovery/DevelopmentConfigTest.php
+++ b/test/ConfigDiscovery/DevelopmentConfigTest.php
@@ -14,8 +14,10 @@ use Zend\ComponentInstaller\ConfigDiscovery\DevelopmentConfig;
 
 class DevelopmentConfigTest extends TestCase
 {
+    /** @var vfsStreamDirectory */
     private $configDir;
 
+    /** @var DevelopmentConfig */
     private $locator;
 
     public function setUp()
@@ -49,6 +51,8 @@ class DevelopmentConfigTest extends TestCase
 
     /**
      * @dataProvider validDevelopmentConfigContents
+     *
+     * @param string $contents
      */
     public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
     {

--- a/test/ConfigDiscovery/DevelopmentConfigTest.php
+++ b/test/ConfigDiscovery/DevelopmentConfigTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\ConfigDiscovery;

--- a/test/ConfigDiscovery/ExpressiveConfigTest.php
+++ b/test/ConfigDiscovery/ExpressiveConfigTest.php
@@ -14,8 +14,10 @@ use Zend\ComponentInstaller\ConfigDiscovery\ExpressiveConfig;
 
 class ExpressiveConfigTest extends TestCase
 {
+    /** @var vfsStreamDirectory */
     private $configDir;
 
+    /** @var ExpressiveConfig */
     private $locator;
 
     public function setUp()
@@ -55,6 +57,8 @@ class ExpressiveConfigTest extends TestCase
 
     /**
      * @dataProvider validExpressiveConfigContents
+     *
+     * @param string $contents
      */
     public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
     {

--- a/test/ConfigDiscovery/ExpressiveConfigTest.php
+++ b/test/ConfigDiscovery/ExpressiveConfigTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\ComponentInstaller\ConfigDiscovery;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ComponentInstaller\ConfigDiscovery\ExpressiveConfig;
 
 class ExpressiveConfigTest extends TestCase

--- a/test/ConfigDiscovery/ExpressiveConfigTest.php
+++ b/test/ConfigDiscovery/ExpressiveConfigTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\ConfigDiscovery;

--- a/test/ConfigDiscovery/ModulesConfig.php
+++ b/test/ConfigDiscovery/ModulesConfig.php
@@ -14,8 +14,10 @@ use Zend\ComponentInstaller\ConfigDiscovery\ModulesConfig;
 
 class ModulesConfigTest extends TestCase
 {
+    /** @var vfsStreamDirectory */
     private $configDir;
 
+    /** @var ModulesConfig */
     private $locator;
 
     public function setUp()
@@ -49,6 +51,8 @@ class ModulesConfigTest extends TestCase
 
     /**
      * @dataProvider validModulesConfigContents
+     *
+     * @param string $contents
      */
     public function testLocateReturnsTrueWhenFileExistsAndHasExpectedContent($contents)
     {

--- a/test/ConfigDiscovery/ModulesConfig.php
+++ b/test/ConfigDiscovery/ModulesConfig.php
@@ -9,7 +9,7 @@ namespace ZendTest\ComponentInstaller\ConfigDiscovery;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ComponentInstaller\ConfigDiscovery\ModulesConfig;
 
 class ModulesConfigTest extends TestCase

--- a/test/ConfigDiscovery/ModulesConfig.php
+++ b/test/ConfigDiscovery/ModulesConfig.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\ConfigDiscovery;

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -9,8 +9,7 @@ namespace ZendTest\ComponentInstaller;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_ExpectationFailedException as ExpectationFailedException;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\ComponentInstaller\Collection;
 use Zend\ComponentInstaller\ConfigDiscovery;
 use Zend\ComponentInstaller\ConfigOption;
@@ -96,14 +95,14 @@ class ConfigDiscoveryTest extends TestCase
     public function assertOptionsContainsNoopInjector(Collection $options)
     {
         if ($options->isEmpty()) {
-            throw new ExpectationFailedException('Options array is empty; no NoopInjector found!');
+            $this->fail('Options array is empty; no NoopInjector found!');
         }
 
         $options = $options->toArray();
         $injector = array_shift($options)->getInjector();
 
         if (! $injector instanceof NoopInjector) {
-            throw new ExpectationFailedException('Options array does not contain a NoopInjector!');
+            $this->fail('Options array does not contain a NoopInjector!');
         }
     }
 
@@ -111,7 +110,7 @@ class ConfigDiscoveryTest extends TestCase
     {
         foreach ($options as $option) {
             if (! $option instanceof ConfigOption) {
-                throw new ExpectationFailedException(sprintf(
+                $this->fail(sprintf(
                     'Invalid option returned: %s',
                     (is_object($option) ? get_class($option) : gettype($option))
                 ));
@@ -122,7 +121,7 @@ class ConfigDiscoveryTest extends TestCase
             }
         }
 
-        throw new ExpectationFailedException(sprintf(
+        $this->fail(sprintf(
             'Injector of type %s was not found in the options',
             $injectorType
         ));
@@ -134,7 +133,7 @@ class ConfigDiscoveryTest extends TestCase
 
         foreach ($chain->getCollection() as $injector) {
             if (! $injector instanceof InjectorInterface) {
-                throw new ExpectationFailedException(sprintf(
+                $this->fail(sprintf(
                     'Invalid Injector returned: %s',
                     (is_object($injector) ? get_class($injector) : gettype($injector))
                 ));
@@ -145,7 +144,7 @@ class ConfigDiscoveryTest extends TestCase
             }
         }
 
-        throw new ExpectationFailedException(sprintf(
+        $this->fail(sprintf(
             'Injector of type %s was not found in the options',
             $injectorType
         ));

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -20,9 +20,17 @@ use Zend\ComponentInstaller\Injector\NoopInjector;
 
 class ConfigDiscoveryTest extends TestCase
 {
+    /** @var vfsStreamDirectory */
     private $projectRoot;
 
+    /** @var ConfigDiscovery\ */
     private $discovery;
+
+    /** @var Collection */
+    private $allTypes;
+
+    /** @var string[] */
+    private $injectorTypes;
 
     public function setUp()
     {
@@ -247,6 +255,11 @@ class ConfigDiscoveryTest extends TestCase
 
     /**
      * @dataProvider configFileSubset
+     *
+     * @param string $seedMethod
+     * @param string $type
+     * @param string $expected
+     * @param bool $chain
      */
     public function testGetAvailableConfigOptionsCanReturnsSubsetOfOptionsBaseOnPackageType(
         $seedMethod,

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -112,7 +112,7 @@ class ConfigDiscoveryTest extends TestCase
             if (! $option instanceof ConfigOption) {
                 $this->fail(sprintf(
                     'Invalid option returned: %s',
-                    (is_object($option) ? get_class($option) : gettype($option))
+                    is_object($option) ? get_class($option) : gettype($option)
                 ));
             }
 
@@ -135,7 +135,7 @@ class ConfigDiscoveryTest extends TestCase
             if (! $injector instanceof InjectorInterface) {
                 $this->fail(sprintf(
                     'Invalid Injector returned: %s',
-                    (is_object($injector) ? get_class($injector) : gettype($injector))
+                    is_object($injector) ? get_class($injector) : gettype($injector)
                 ));
             }
 

--- a/test/ConfigDiscoveryTest.php
+++ b/test/ConfigDiscoveryTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller;

--- a/test/Injector/AbstractInjectorTestCase.php
+++ b/test/Injector/AbstractInjectorTestCase.php
@@ -112,7 +112,7 @@ abstract class AbstractInjectorTestCase extends TestCase
      *
      * @param string $contents
      */
-    public function testRemoveDoesNothingIfPackageIsNotInConfigFile($type, $contents)
+    public function testRemoveDoesNothingIfPackageIsNotInConfigFile($contents)
     {
         vfsStream::newFile($this->configFile)
             ->at($this->configDir)
@@ -132,7 +132,7 @@ abstract class AbstractInjectorTestCase extends TestCase
      * @param string $initialContents
      * @param string $expectedContents
      */
-    public function testRemoveRemovesPackageFromConfigurationWhenFound($type, $initialContents, $expectedContents)
+    public function testRemoveRemovesPackageFromConfigurationWhenFound($initialContents, $expectedContents)
     {
         vfsStream::newFile($this->configFile)
             ->at($this->configDir)

--- a/test/Injector/AbstractInjectorTestCase.php
+++ b/test/Injector/AbstractInjectorTestCase.php
@@ -15,14 +15,19 @@ use Prophecy\Argument;
 
 abstract class AbstractInjectorTestCase extends TestCase
 {
+    /** @var vfsStreamDirectory */
     protected $configDir;
 
+    /** @var string */
     protected $configFile;
 
+    /** @var AbstractInjector */
     protected $injector;
 
+    /** @var string */
     protected $injectorClass;
 
+    /** @var int[] */
     protected $injectorTypesAllowed = [];
 
     public function setUp()
@@ -39,6 +44,9 @@ abstract class AbstractInjectorTestCase extends TestCase
 
     /**
      * @dataProvider allowedTypes
+     *
+     * @param string $type
+     * @param bool $expected
      */
     public function testRegistersTypesReturnsExpectedBooleanBasedOnType($type, $expected)
     {
@@ -54,6 +62,10 @@ abstract class AbstractInjectorTestCase extends TestCase
 
     /**
      * @dataProvider injectComponentProvider
+     *
+     * @param string $type
+     * @param string $initialContents
+     * @param string $expectedContents
      */
     public function testInjectAddsPackageToModulesListInAppropriateLocation($type, $initialContents, $expectedContents)
     {
@@ -74,6 +86,9 @@ abstract class AbstractInjectorTestCase extends TestCase
 
     /**
      * @dataProvider packageAlreadyRegisteredProvider
+     *
+     * @param string $contents
+     * @param string $type
      */
     public function testInjectDoesNotModifyContentsIfPackageIsAlreadyRegistered($contents, $type)
     {
@@ -94,6 +109,8 @@ abstract class AbstractInjectorTestCase extends TestCase
 
     /**
      * @dataProvider emptyConfiguration
+     *
+     * @param string $contents
      */
     public function testRemoveDoesNothingIfPackageIsNotInConfigFile($type, $contents)
     {
@@ -111,6 +128,9 @@ abstract class AbstractInjectorTestCase extends TestCase
 
     /**
      * @dataProvider packagePopulatedInConfiguration
+     *
+     * @param string $initialContents
+     * @param string $expectedContents
      */
     public function testRemoveRemovesPackageFromConfigurationWhenFound($type, $initialContents, $expectedContents)
     {

--- a/test/Injector/AbstractInjectorTestCase.php
+++ b/test/Injector/AbstractInjectorTestCase.php
@@ -10,7 +10,7 @@ namespace ZendTest\ComponentInstaller\Injector;
 use Composer\IO\IOInterface;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 abstract class AbstractInjectorTestCase extends TestCase

--- a/test/Injector/AbstractInjectorTestCase.php
+++ b/test/Injector/AbstractInjectorTestCase.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -28,10 +28,10 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
     public function allowedTypes()
     {
         return [
-            'config-provider' => [ApplicationConfigInjector::TYPE_CONFIG_PROVIDER, false],
-            'component'       => [ApplicationConfigInjector::TYPE_COMPONENT, true],
-            'module'          => [ApplicationConfigInjector::TYPE_MODULE, true],
-            'dependency'      => [ApplicationConfigInjector::TYPE_DEPENDENCY, true],
+            'config-provider'            => [ApplicationConfigInjector::TYPE_CONFIG_PROVIDER, false],
+            'component'                  => [ApplicationConfigInjector::TYPE_COMPONENT, true],
+            'module'                     => [ApplicationConfigInjector::TYPE_MODULE, true],
+            'dependency'                 => [ApplicationConfigInjector::TYPE_DEPENDENCY, true],
             'before-application-modules' => [ApplicationConfigInjector::TYPE_BEFORE_APPLICATION, true],
         ];
     }
@@ -68,13 +68,12 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
         $baseContentsShortArray = '<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n    ]\n];";
-        return [
-            'component-long-array'  => [ApplicationConfigInjector::TYPE_COMPONENT, $baseContentsLongArray],
-            'component-short-array' => [ApplicationConfigInjector::TYPE_COMPONENT, $baseContentsShortArray],
-            'module-long-array'     => [ApplicationConfigInjector::TYPE_MODULE,    $baseContentsLongArray],
-            'module-short-array'    => [ApplicationConfigInjector::TYPE_MODULE,    $baseContentsShortArray],
-        ];
         // @codingStandardsIgnoreEnd
+
+        return [
+            'long-array'  => [$baseContentsLongArray],
+            'short-array' => [$baseContentsShortArray],
+        ];
     }
 
     public function packagePopulatedInConfiguration()
@@ -83,10 +82,8 @@ class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
         $baseContentsShortArray = '<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n    ]\n];";
         return [
-            'component-long-array'  => [ApplicationConfigInjector::TYPE_COMPONENT, '<' . "?php\nreturn array(\n    'modules' => array(\n        'Foo\Bar',\n        'Application',\n    )\n);", $baseContentsLongArray],
-            'component-short-array' => [ApplicationConfigInjector::TYPE_COMPONENT, '<' . "?php\nreturn [\n    'modules' => [\n        'Foo\Bar',\n        'Application',\n    ]\n];",           $baseContentsShortArray],
-            'module-long-array'     => [ApplicationConfigInjector::TYPE_MODULE,    '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n        'Foo\Bar',\n    )\n);", $baseContentsLongArray],
-            'module-short-array'    => [ApplicationConfigInjector::TYPE_MODULE,    '<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n        'Foo\Bar',\n    ]\n];",           $baseContentsShortArray],
+            'long-array'  => ['<' . "?php\nreturn array(\n    'modules' => array(\n        'Foo\Bar',\n        'Application',\n    )\n);", $baseContentsLongArray],
+            'short-array' => ['<' . "?php\nreturn [\n    'modules' => [\n        'Foo\Bar',\n        'Application',\n    ]\n];",           $baseContentsShortArray],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -11,10 +11,13 @@ use Zend\ComponentInstaller\Injector\ApplicationConfigInjector;
 
 class ApplicationConfigInjectorTest extends AbstractInjectorTestCase
 {
+    /** @var string */
     protected $configFile = 'config/application.config.php';
 
+    /** @var string */
     protected $injectorClass = ApplicationConfigInjector::class;
 
+    /** @var int[] */
     protected $injectorTypesAllowed = [
         ApplicationConfigInjector::TYPE_COMPONENT,
         ApplicationConfigInjector::TYPE_MODULE,

--- a/test/Injector/ApplicationConfigInjectorTest.php
+++ b/test/Injector/ApplicationConfigInjectorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -100,20 +100,20 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-fqcn.config.php');
         $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-globally-qualified.config.php');
         $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/expressive-empty-import.config.php');
+        // @codingStandardsIgnoreEnd
 
         $fqcnShortArray              = $this->convertToShortArraySyntax($fqcnLongArray);
         $globallyQualifiedShortArray = $this->convertToShortArraySyntax($globallyQualifiedLongArray);
         $importShortArray            = $this->convertToShortArraySyntax($importLongArray);
 
         return [
-            'fqcn-long-array'           => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
-            'global-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
-            'import-long-array'         => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
-            'fqcn-short-array'          => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
-            'global-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
-            'import-short-array'        => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
+            'fqcn-long-array'    => [$fqcnLongArray],
+            'global-long-array'  => [$globallyQualifiedLongArray],
+            'import-long-array'  => [$importLongArray],
+            'fqcn-short-array'   => [$fqcnShortArray],
+            'global-short-array' => [$globallyQualifiedShortArray],
+            'import-short-array' => [$importShortArray],
         ];
-        // @codingStandardsIgnoreEnd
     }
 
     public function packagePopulatedInConfiguration()
@@ -140,14 +140,14 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
         $expectedContentsImportShortArrayAltIndent   = $this->convertToShortArraySyntax($expectedContentsImportLongArrayAltIndent);
 
         return [
-            'fqcn-long-array'               => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
-            'global-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
-            'import-long-array'             => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
-            'import-long-array-alt-indent'  => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArrayAltIndent,    $expectedContentsImportLongArrayAltIndent],
-            'fqcn-short-array'              => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
-            'global-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
-            'import-short-array'            => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
-            'import-short-array-alt-indent' => [ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArrayAltIndent,   $expectedContentsImportShortArrayAltIndent],
+            'fqcn-long-array'               => [$baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
+            'global-long-array'             => [$baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
+            'import-long-array'             => [$baseContentsImportLongArray,             $expectedContentsImportLongArray],
+            'import-long-array-alt-indent'  => [$baseContentsImportLongArrayAltIndent,    $expectedContentsImportLongArrayAltIndent],
+            'fqcn-short-array'              => [$baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
+            'global-short-array'            => [$baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
+            'import-short-array'            => [$baseContentsImportShortArray,            $expectedContentsImportShortArray],
+            'import-short-array-alt-indent' => [$baseContentsImportShortArrayAltIndent,   $expectedContentsImportShortArrayAltIndent],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -11,10 +11,13 @@ use Zend\ComponentInstaller\Injector\ConfigAggregatorInjector;
 
 class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
 {
+    /** @var string */
     protected $configFile = 'config/config.php';
 
+    /** @var string */
     protected $injectorClass = ConfigAggregatorInjector::class;
 
+    /** @var int[] */
     protected $injectorTypesAllowed = [
         ConfigAggregatorInjector::TYPE_CONFIG_PROVIDER,
     ];

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -11,10 +11,13 @@ use Zend\ComponentInstaller\Injector\DevelopmentConfigInjector;
 
 class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
 {
+    /** @var string */
     protected $configFile = 'config/development.config.php.dist';
 
+    /** @var string */
     protected $injectorClass = DevelopmentConfigInjector::class;
 
+    /** @var int[] */
     protected $injectorTypesAllowed = [
         DevelopmentConfigInjector::TYPE_COMPONENT,
         DevelopmentConfigInjector::TYPE_MODULE,

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -28,10 +28,10 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
     public function allowedTypes()
     {
         return [
-            'config-provider' => [DevelopmentConfigInjector::TYPE_CONFIG_PROVIDER, false],
-            'component'       => [DevelopmentConfigInjector::TYPE_COMPONENT, true],
-            'module'          => [DevelopmentConfigInjector::TYPE_MODULE, true],
-            'dependency'      => [DevelopmentConfigInjector::TYPE_DEPENDENCY, true],
+            'config-provider'            => [DevelopmentConfigInjector::TYPE_CONFIG_PROVIDER, false],
+            'component'                  => [DevelopmentConfigInjector::TYPE_COMPONENT, true],
+            'module'                     => [DevelopmentConfigInjector::TYPE_MODULE, true],
+            'dependency'                 => [DevelopmentConfigInjector::TYPE_DEPENDENCY, true],
             'before-application-modules' => [DevelopmentConfigInjector::TYPE_BEFORE_APPLICATION, true],
         ];
     }
@@ -67,13 +67,12 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
         $baseContentsShortArray = '<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n    ]\n];";
-        return [
-            'component-long-array'  => [DevelopmentConfigInjector::TYPE_COMPONENT, $baseContentsLongArray],
-            'component-short-array' => [DevelopmentConfigInjector::TYPE_COMPONENT, $baseContentsShortArray],
-            'module-long-array'     => [DevelopmentConfigInjector::TYPE_MODULE,    $baseContentsLongArray],
-            'module-short-array'    => [DevelopmentConfigInjector::TYPE_MODULE,    $baseContentsShortArray],
-        ];
         // @codingStandardsIgnoreEnd
+
+        return [
+            'long-array'  => [$baseContentsLongArray],
+            'short-array' => [$baseContentsShortArray],
+        ];
     }
 
     public function packagePopulatedInConfiguration()
@@ -82,10 +81,8 @@ class DevelopmentConfigInjectorTest extends AbstractInjectorTestCase
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n    )\n);";
         $baseContentsShortArray = '<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n    ]\n];";
         return [
-            'component-long-array'  => [DevelopmentConfigInjector::TYPE_COMPONENT, '<' . "?php\nreturn array(\n    'modules' => array(\n        'Foo\Bar',\n        'Application',\n    )\n);", $baseContentsLongArray],
-            'component-short-array' => [DevelopmentConfigInjector::TYPE_COMPONENT, '<' . "?php\nreturn [\n    'modules' => [\n        'Foo\Bar',\n        'Application',\n    ]\n];",           $baseContentsShortArray],
-            'module-long-array'     => [DevelopmentConfigInjector::TYPE_MODULE,    '<' . "?php\nreturn array(\n    'modules' => array(\n        'Application',\n        'Foo\Bar',\n    )\n);", $baseContentsLongArray],
-            'module-short-array'    => [DevelopmentConfigInjector::TYPE_MODULE,    '<' . "?php\nreturn [\n    'modules' => [\n        'Application',\n        'Foo\Bar',\n    ]\n];",           $baseContentsShortArray],
+            'long-array'  => ['<' . "?php\nreturn array(\n    'modules' => array(\n        'Foo\Bar',\n        'Application',\n    )\n);", $baseContentsLongArray],
+            'short-array' => ['<' . "?php\nreturn [\n    'modules' => [\n        'Foo\Bar',\n        'Application',\n    ]\n];",           $baseContentsShortArray],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/DevelopmentConfigInjectorTest.php
+++ b/test/Injector/DevelopmentConfigInjectorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;

--- a/test/Injector/ExpressiveConfigInjectorTest.php
+++ b/test/Injector/ExpressiveConfigInjectorTest.php
@@ -11,10 +11,13 @@ use Zend\ComponentInstaller\Injector\ExpressiveConfigInjector;
 
 class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
 {
+    /** @var string */
     protected $configFile = 'config/config.php';
 
+    /** @var string */
     protected $injectorClass = ExpressiveConfigInjector::class;
 
+    /** @var int[] */
     protected $injectorTypesAllowed = [
         ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER,
     ];

--- a/test/Injector/ExpressiveConfigInjectorTest.php
+++ b/test/Injector/ExpressiveConfigInjectorTest.php
@@ -94,20 +94,20 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
         $fqcnLongArray              = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-empty-fqcn.config.php');
         $globallyQualifiedLongArray = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-empty-globally-qualified.config.php');
         $importLongArray            = file_get_contents(__DIR__ . '/TestAsset/legacy-expressive-empty-import.config.php');
+        // @codingStandardsIgnoreEnd
 
         $fqcnShortArray              = $this->convertToShortArraySyntax($fqcnLongArray);
         $globallyQualifiedShortArray = $this->convertToShortArraySyntax($globallyQualifiedLongArray);
         $importShortArray            = $this->convertToShortArraySyntax($importLongArray);
 
         return [
-            'fqcn-long-array'    => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnLongArray],
-            'global-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedLongArray],
-            'import-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importLongArray],
-            'fqcn-short-array'   => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $fqcnShortArray],
-            'global-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $globallyQualifiedShortArray],
-            'import-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $importShortArray],
+            'fqcn-long-array'    => [$fqcnLongArray],
+            'global-long-array'  => [$globallyQualifiedLongArray],
+            'import-long-array'  => [$importLongArray],
+            'fqcn-short-array'   => [$fqcnShortArray],
+            'global-short-array' => [$globallyQualifiedShortArray],
+            'import-short-array' => [$importShortArray],
         ];
-        // @codingStandardsIgnoreEnd
     }
 
     public function packagePopulatedInConfiguration()
@@ -130,12 +130,12 @@ class ExpressiveConfigInjectorTest extends AbstractInjectorTestCase
         $expectedContentsImportShortArray            = $this->convertToShortArraySyntax($expectedContentsImportLongArray);
 
         return [
-            'fqcn-long-array'    => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
-            'global-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
-            'import-long-array'  => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportLongArray,             $expectedContentsImportLongArray],
-            'fqcn-short-array'   => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
-            'global-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
-            'import-short-array' => [ExpressiveConfigInjector::TYPE_CONFIG_PROVIDER, $baseContentsImportShortArray,            $expectedContentsImportShortArray],
+            'fqcn-long-array'    => [$baseContentsFqcnLongArray,               $expectedContentsFqcnLongArray],
+            'global-long-array'  => [$baseContentsGloballyQualifiedLongArray,  $expectedContentsGloballyQualifiedLongArray],
+            'import-long-array'  => [$baseContentsImportLongArray,             $expectedContentsImportLongArray],
+            'fqcn-short-array'   => [$baseContentsFqcnShortArray,              $expectedContentsFqcnShortArray],
+            'global-short-array' => [$baseContentsGloballyQualifiedShortArray, $expectedContentsGloballyQualifiedShortArray],
+            'import-short-array' => [$baseContentsImportShortArray,            $expectedContentsImportShortArray],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/ExpressiveConfigInjectorTest.php
+++ b/test/Injector/ExpressiveConfigInjectorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;

--- a/test/Injector/ModulesConfigInjectorTest.php
+++ b/test/Injector/ModulesConfigInjectorTest.php
@@ -28,10 +28,10 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
     public function allowedTypes()
     {
         return [
-            'config-provider' => [ModulesConfigInjector::TYPE_CONFIG_PROVIDER, false],
-            'component'       => [ModulesConfigInjector::TYPE_COMPONENT, true],
-            'module'          => [ModulesConfigInjector::TYPE_MODULE, true],
-            'dependency'      => [ModulesConfigInjector::TYPE_DEPENDENCY, true],
+            'config-provider'            => [ModulesConfigInjector::TYPE_CONFIG_PROVIDER, false],
+            'component'                  => [ModulesConfigInjector::TYPE_COMPONENT, true],
+            'module'                     => [ModulesConfigInjector::TYPE_MODULE, true],
+            'dependency'                 => [ModulesConfigInjector::TYPE_DEPENDENCY, true],
             'before-application-modules' => [ModulesConfigInjector::TYPE_BEFORE_APPLICATION, true],
         ];
     }
@@ -67,13 +67,12 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         // @codingStandardsIgnoreStart
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'Application',\n);";
         $baseContentsShortArray = '<' . "?php\nreturn [\n    'Application',\n];";
-        return [
-            'component-long-array'  => [ModulesConfigInjector::TYPE_COMPONENT, $baseContentsLongArray],
-            'component-short-array' => [ModulesConfigInjector::TYPE_COMPONENT, $baseContentsShortArray],
-            'module-long-array'     => [ModulesConfigInjector::TYPE_MODULE,    $baseContentsLongArray],
-            'module-short-array'    => [ModulesConfigInjector::TYPE_MODULE,    $baseContentsShortArray],
-        ];
         // @codingStandardsIgnoreEnd
+
+        return [
+            'long-array'  => [$baseContentsLongArray],
+            'short-array' => [$baseContentsShortArray],
+        ];
     }
 
     public function packagePopulatedInConfiguration()
@@ -82,10 +81,8 @@ class ModulesConfigInjectorTest extends AbstractInjectorTestCase
         $baseContentsLongArray  = '<' . "?php\nreturn array(\n    'Application',\n);";
         $baseContentsShortArray = '<' . "?php\nreturn [\n    'Application',\n];";
         return [
-            'component-long-array'  => [ModulesConfigInjector::TYPE_COMPONENT, '<' . "?php\nreturn array(\n    'Foo\Bar',\n    'Application',\n);", $baseContentsLongArray],
-            'component-short-array' => [ModulesConfigInjector::TYPE_COMPONENT, '<' . "?php\nreturn [\n    'Foo\Bar',\n    'Application',\n];",      $baseContentsShortArray],
-            'module-long-array'     => [ModulesConfigInjector::TYPE_MODULE,    '<' . "?php\nreturn array(\n    'Application',\n    'Foo\Bar',\n);", $baseContentsLongArray],
-            'module-short-array'    => [ModulesConfigInjector::TYPE_MODULE,    '<' . "?php\nreturn [\n    'Application',\n    'Foo\Bar',\n];",      $baseContentsShortArray],
+            'long-array'  => ['<' . "?php\nreturn array(\n    'Foo\Bar',\n    'Application',\n);", $baseContentsLongArray],
+            'short-array' => ['<' . "?php\nreturn [\n    'Foo\Bar',\n    'Application',\n];",      $baseContentsShortArray],
         ];
         // @codingStandardsIgnoreEnd
     }

--- a/test/Injector/ModulesConfigInjectorTest.php
+++ b/test/Injector/ModulesConfigInjectorTest.php
@@ -11,10 +11,13 @@ use Zend\ComponentInstaller\Injector\ModulesConfigInjector;
 
 class ModulesConfigInjectorTest extends AbstractInjectorTestCase
 {
+    /** @var string */
     protected $configFile = 'config/modules.config.php';
 
+    /** @var string */
     protected $injectorClass = ModulesConfigInjector::class;
 
+    /** @var int[] */
     protected $injectorTypesAllowed = [
         ModulesConfigInjector::TYPE_COMPONENT,
         ModulesConfigInjector::TYPE_MODULE,

--- a/test/Injector/ModulesConfigInjectorTest.php
+++ b/test/Injector/ModulesConfigInjectorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -8,8 +8,6 @@
 namespace ZendTest\ComponentInstaller\Injector;
 
 use PHPUnit\Framework\TestCase;
-use Composer\IO\IOInterface;
-use Prophecy\Argument;
 use Zend\ComponentInstaller\Injector\NoopInjector;
 
 class NoopInjectorTest extends TestCase
@@ -53,15 +51,15 @@ class NoopInjectorTest extends TestCase
      */
     public function testInjectIsANoop($type)
     {
-        $io = $this->prophesize(IOInterface::class);
-        $io->write(Argument::any())->shouldNotBeCalled();
-        $this->assertNull($this->injector->inject('Foo\Bar', $type, $io->reveal()));
+        $injected = $this->injector->inject('Foo\Bar', $type);
+
+        $this->assertFalse($injected);
     }
 
     public function testRemoveIsANoop()
     {
-        $io = $this->prophesize(IOInterface::class);
-        $io->write(Argument::any())->shouldNotBeCalled();
-        $this->assertNull($this->injector->remove('Foo\Bar', $io->reveal()));
+        $removed = $this->injector->remove('Foo\Bar');
+
+        $this->assertFalse($removed);
     }
 }

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -14,6 +14,9 @@ use Zend\ComponentInstaller\Injector\NoopInjector;
 
 class NoopInjectorTest extends TestCase
 {
+    /** @var NoopInjector */
+    private $injector;
+
     public function setUp()
     {
         $this->injector = new NoopInjector();
@@ -21,6 +24,8 @@ class NoopInjectorTest extends TestCase
 
     /**
      * @dataProvider packageTypes
+     *
+     * @param string $type
      */
     public function testWillRegisterAnyType($type)
     {
@@ -43,6 +48,8 @@ class NoopInjectorTest extends TestCase
 
     /**
      * @dataProvider packageTypes
+     *
+     * @param string $type
      */
     public function testInjectIsANoop($type)
     {

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -58,10 +58,7 @@ class NoopInjectorTest extends TestCase
         $this->assertNull($this->injector->inject('Foo\Bar', $type, $io->reveal()));
     }
 
-    /**
-     * @dataProvider packageTypes
-     */
-    public function testRemoveIsANoop($type)
+    public function testRemoveIsANoop()
     {
         $io = $this->prophesize(IOInterface::class);
         $io->write(Argument::any())->shouldNotBeCalled();

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\ComponentInstaller\Injector;
 
+use PHPUnit\Framework\TestCase;
 use Composer\IO\IOInterface;
-use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Zend\ComponentInstaller\Injector\NoopInjector;
 

--- a/test/Injector/NoopInjectorTest.php
+++ b/test/Injector/NoopInjectorTest.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies Ltd (http://www.zend.com)
+ * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\ComponentInstaller\Injector;


### PR DESCRIPTION
During work on https://github.com/zendframework/zend-expressive-tooling/pull/12 discovered that usage injector of this library is quite hard, because inject/remove methods requires `IOInterface` from composer to output results there.

This PR refactor the library slightly, add QA tools and change interface of injector.

The main commit with change interface is 774cc6e.
Now `inject` and `remove` methods do not require `IOInterface` parameter and return bool on to indicate success or skipped operation.

`ComponentInstaller` interface is not changed, added there try...catch and output message based on response from methods `inject`/`remove`.

As interface of injector is changed this PR contains BC Break, so it should be released with version 0.7.