### PR TITLE
Ensure we can detect globally qualified config providers

### DIFF
--- a/src/Injector/ConfigAggregatorInjector.php
+++ b/src/Injector/ConfigAggregatorInjector.php
@@ -78,11 +78,14 @@ class ConfigAggregatorInjector extends AbstractInjector
      */
     public function __construct($projectRoot = '')
     {
+        $ns = preg_quote('\\');
         $this->isRegisteredPattern = '/new (?:'
-            . preg_quote('\\')
+            . $ns
             . '?'
             . preg_quote('Zend\ConfigAggregator\\')
-            . ')?ConfigAggregator\(\s*(?:array\(|\[).*\s+%s::class/s';
+            . ')?ConfigAggregator\(\s*(?:array\(|\[).*\s+'
+            . $ns
+            . '?%s::class/s';
 
         $this->injectionPatterns[self::TYPE_CONFIG_PROVIDER]['pattern'] = sprintf(
             "/(new (?:%s?%s)?ConfigAggregator\(\s*(?:array\(|\[)\s*)(?:\r|\n|\r\n)(\s*)/",

--- a/test/Injector/ConfigAggregatorInjectorTest.php
+++ b/test/Injector/ConfigAggregatorInjectorTest.php
@@ -7,6 +7,7 @@
 
 namespace ZendTest\ComponentInstaller\Injector;
 
+use org\bovigo\vfs\vfsStream;
 use Zend\ComponentInstaller\Injector\ConfigAggregatorInjector;
 
 class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
@@ -150,5 +151,15 @@ class ConfigAggregatorInjectorTest extends AbstractInjectorTestCase
             'import-short-array-alt-indent' => [$baseContentsImportShortArrayAltIndent,   $expectedContentsImportShortArrayAltIndent],
         ];
         // @codingStandardsIgnoreEnd
+    }
+
+    public function testProperlyDetectsExistingConfigProviderInConfigWithMixedRelativeAndGloballyQualifiedNames()
+    {
+        $contents = file_get_contents(__DIR__ . '/TestAsset/expressive-application-from-skeleton.config.php');
+        vfsStream::newFile('config/config.php')
+            ->at($this->configDir)
+            ->setContent($contents);
+
+        $this->assertTrue($this->injector->isRegistered('Zend\Validator\ConfigProvider'));
     }
 }

--- a/test/Injector/TestAsset/expressive-application-from-skeleton.config.php
+++ b/test/Injector/TestAsset/expressive-application-from-skeleton.config.php
@@ -1,0 +1,37 @@
+<?php
+
+use Zend\ConfigAggregator\ArrayProvider;
+use Zend\ConfigAggregator\ConfigAggregator;
+use Zend\ConfigAggregator\PhpFileProvider;
+
+// To enable or disable caching, set the `ConfigAggregator::ENABLE_CACHE` boolean in
+// `config/autoload/local.php`.
+$cacheConfig = [
+    'config_cache_path' => 'data/config-cache.php',
+];
+
+$aggregator = new ConfigAggregator([
+    \Zend\Validator\ConfigProvider::class,
+    \Zend\InputFilter\ConfigProvider::class,
+    \Zend\Filter\ConfigProvider::class,
+    \Zend\Mail\ConfigProvider::class,
+    \Contact\ConfigProvider::class,
+    // Include cache configuration
+    new ArrayProvider($cacheConfig),
+
+    // Default App module config
+    App\ConfigProvider::class,
+
+    // Load application config in a pre-defined order in such a way that local settings
+    // overwrite global settings. (Loaded as first to last):
+    //   - `global.php`
+    //   - `*.global.php`
+    //   - `local.php`
+    //   - `*.local.php`
+    new PhpFileProvider('config/autoload/{{,*.}global,{,*.}local}.php'),
+
+    // Load development config if it exists
+    new PhpFileProvider('config/development.config.php'),
+], $cacheConfig['config_cache_path']);
+
+return $aggregator->getMergedConfig();


### PR DESCRIPTION
This fixes #37. Essentially, the `$isRegisteredPattern` was failing
if the `$package` was globally qualified within the configuration (e.g.,
`\Zend\Validator\ConfigProvider`). The pattern now checks for an
optional `\\` prefix to the FQCN.