### PR TITLE
Errors when installing package that defines multiple Paths for a PSR-4 Autoload

### DIFF
--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -222,48 +222,52 @@ class ComponentInstaller implements
 
         $autoload = $package->getAutoload();
         foreach ($autoload as $type => $map) {
-            foreach ($map as $namespace => $path) {
-                switch ($type) {
-                    case 'classmap':
-                        $fullPath = sprintf('%s/%s', $packagePath, $path);
-                        if (is_dir(rtrim($fullPath, '/'))) {
-                            $modulePath = sprintf('%s%s', $fullPath, 'Module.php');
-                        } elseif (substr($path, -10) === 'Module.php') {
-                            $modulePath = $fullPath;
-                        } else {
-                            continue 2;
-                        }
-                        break;
-                    case 'files':
-                        if (substr($path, -10) !== 'Module.php') {
-                            continue 2;
-                        }
-                        $modulePath = sprintf('%s/%s', $packagePath, $path);
-                        break;
-                    case 'psr-0':
-                        $modulePath = sprintf(
-                            '%s/%s%s%s',
-                            $packagePath,
-                            $path,
-                            str_replace('\\', '/', $namespace),
-                            'Module.php'
-                        );
-                        break;
-                    case 'psr-4':
-                        $modulePath = sprintf(
-                            '%s/%s%s',
-                            $packagePath,
-                            $path,
-                            'Module.php'
-                        );
-                        break;
-                    default:
-                        continue 2;
-                }
+            foreach ($map as $namespace => $paths) {
+                $paths = (array)$paths;
 
-                if (file_exists($modulePath)) {
-                    if ($result = $this->getModuleDependencies($modulePath)) {
-                        $dependencies += $result;
+                foreach ($paths as $path) {
+                    switch ($type) {
+                        case 'classmap':
+                            $fullPath = sprintf('%s/%s', $packagePath, $path);
+                            if (is_dir(rtrim($fullPath, '/'))) {
+                                $modulePath = sprintf('%s%s', $fullPath, 'Module.php');
+                            } elseif (substr($path, -10) === 'Module.php') {
+                                $modulePath = $fullPath;
+                            } else {
+                                continue 2;
+                            }
+                            break;
+                        case 'files':
+                            if (substr($path, -10) !== 'Module.php') {
+                                continue 2;
+                            }
+                            $modulePath = sprintf('%s/%s', $packagePath, $path);
+                            break;
+                        case 'psr-0':
+                            $modulePath = sprintf(
+                                '%s/%s%s%s',
+                                $packagePath,
+                                $path,
+                                str_replace('\\', '/', $namespace),
+                                'Module.php'
+                            );
+                            break;
+                        case 'psr-4':
+                            $modulePath = sprintf(
+                                '%s/%s%s',
+                                $packagePath,
+                                $path,
+                                'Module.php'
+                            );
+                            break;
+                        default:
+                            continue 2;
+                    }
+
+                    if (file_exists($modulePath)) {
+                        if ($result = $this->getModuleDependencies($modulePath)) {
+                            $dependencies += $result;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In the file

https://github.com/zendframework/zend-component-installer/blob/master/src/ComponentInstaller.php#L256

This assumes that each PSR-4 Autoload item mentioned in the composer config is a singular item - so they are defined as such:-

```json
{
    "autoload": {
        "psr-4": {
            "Monolog\\": "src/",
            "Vendor\\Namespace\\": ""
        }
    }
}
```

However, the Composer configuration allows that the path for the code be able to be both a string, and an array - e.g.

```json
{
    "autoload": {
        "psr-4": { "Monolog\\": ["src/", "lib/"] }
    }
}
```

When defined with an array of paths, and a config provider, this causes the code to error out and the installation to fail.

Whilst this can be fixed in the package (e.g. https://github.com/Mezzle/queuejitsu/commit/17f17a7c6b1dd0c6ce04209d2089c43e6afe24dc ) - this isn't always going to be possible, and should allow for any valid composer configuration to work.