### PR TITLE
Default to first discovered option

### DIFF
--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -455,10 +455,10 @@ class ComponentInstaller implements
      */
     private function promptToRememberOption(Injector\InjectorInterface $injector, $packageType)
     {
-        $ask = ["\n  <question>Remember this option for other packages of the same type? (y/N)</question>"];
+        $ask = ["\n  <question>Remember this option for other packages of the same type? (Y/n)</question>"];
 
         while (true) {
-            $answer = strtolower($this->io->ask($ask, 'n'));
+            $answer = strtolower($this->io->ask($ask, 'y'));
 
             switch ($answer) {
                 case 'y':

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -415,6 +415,8 @@ class ComponentInstaller implements
             return $cachedInjector;
         }
 
+        // Default to first discovered option; index 0 is always "Do not inject"
+        $default = $options->count() > 1 ? 1 : 0;
         $ask = $options->reduce(function ($ask, $option, $index) {
             $ask[] = sprintf(
                 "  [<comment>%d</comment>] %s\n",
@@ -428,10 +430,10 @@ class ComponentInstaller implements
             "\n  <question>Please select which config file you wish to inject '%s' into:</question>\n",
             $name
         ));
-        $ask[] = '  Make your selection (default is <comment>0</comment>):';
+        $ask[] = sprintf('  Make your selection (default is <comment>%d</comment>):', $default);
 
         while (true) {
-            $answer = $this->io->ask($ask, 0);
+            $answer = $this->io->ask($ask, $default);
 
             if (is_numeric($answer) && isset($options[(int) $answer])) {
                 $injector = $options[(int) $answer]->getInjector();

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -151,7 +151,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -525,7 +525,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -647,7 +647,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -806,7 +806,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -870,7 +870,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -893,7 +893,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -960,7 +960,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1017,7 +1017,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1079,7 +1079,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1268,7 +1268,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1336,7 +1336,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1359,7 +1359,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1432,7 +1432,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {
@@ -1455,7 +1455,7 @@ CONTENT
             }
 
             return true;
-        }), 0)->willReturn(1);
+        }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
             if (! is_array($argument)) {

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -162,7 +162,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing SomeComponent from package some/component');
@@ -536,7 +536,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) use ($packageName) {
             return strstr($argument, sprintf('Installing %s from package some/component', $packageName));
@@ -658,7 +658,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing SomeModule from package some/module');
@@ -817,7 +817,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Component from package some/component');
@@ -895,22 +895,31 @@ CONTENT
             return true;
         }), 1)->willReturn(1);
 
-        $this->io->ask(Argument::that(function ($argument) {
+        $io = $this->io;
+        $askValidator = function ($argument) {
             if (! is_array($argument)) {
-                return false;
+                    return false;
             }
             if (false === strpos($argument[0], 'Remember')) {
                 return false;
             }
 
             return true;
-        }), 'n')->willReturn('n')->shouldBeCalledTimes(2);
+        };
+        $io
+            ->ask(Argument::that($askValidator), 'y')
+            ->will(function () use ($io, $askValidator) {
+                $io
+                    ->ask(Argument::that($askValidator), 'y')
+                    ->willReturn('y');
+                return 'n';
+            });
 
-        $this->io->write(Argument::that(function ($argument) {
+        $io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Component from package some/component');
         }))->shouldBeCalled();
 
-        $this->io->write(Argument::that(function ($argument) {
+        $io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Other\Component from package some/component');
         }))->shouldBeCalled();
 
@@ -971,7 +980,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('n');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Component from package some/component');
@@ -1028,7 +1037,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Other\Component from package other/component');
@@ -1090,7 +1099,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('y');
+        }), 'y')->willReturn('y')->shouldBeCalledTimes(1);
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Component from package some/component');
@@ -1279,7 +1288,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Module from package some/module');
@@ -1370,7 +1379,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('n');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Module from package some/package');
@@ -1466,7 +1475,7 @@ CONTENT
             }
 
             return true;
-        }), 'n')->willReturn('n');
+        }), 'y')->willReturn('n');
 
         $this->io->write(Argument::that(function ($argument) {
             return strstr($argument, 'Installing Some\Module from package some/package');


### PR DESCRIPTION
The primary use case for this plugin is to automate injection of discovered configuration providers and/or modules. By defaulting to "do not inject", we are essentially undoing such automation.

This patch modifies the `ComponentInstaller` class to default to the first provider/module discovered. The implication is that component/module authors should put the most desired location first if defining multiple injection points.

Since this is a rather significant change in behavior, I'm targeting a v2 release.