### PR TITLE
Added whitelisting packages to suppress the inject questions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2017, Zend Technologies USA, Inc.
+Copyright (c) 2015-2018, Zend Technologies USA, Inc.
 
 All rights reserved.
 

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -500,7 +500,7 @@ class ComponentInstaller implements
      */
     private function injectModuleIntoConfig($package, $module, Injector\InjectorInterface $injector, $packageType)
     {
-        $this->io->write(sprintf('<info>Installing %s from package %s</info>', $module, $package));
+        $this->io->write(sprintf('<info>    Installing %s from package %s</info>', $module, $package));
 
         try {
             if (! $injector->inject($module, $packageType)) {
@@ -559,7 +559,7 @@ class ComponentInstaller implements
     private function removeModuleFromConfig($module, $package, Collection $injectors)
     {
         $injectors->each(function (InjectorInterface $injector) use ($module, $package) {
-            $this->io->write(sprintf('<info>Removing %s from package %s</info>', $module, $package));
+            $this->io->write(sprintf('<info>    Removing %s from package %s</info>', $module, $package));
 
             if ($injector->remove($module)) {
                 $this->io->write(sprintf(

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
@@ -191,8 +191,8 @@ class ComponentInstaller implements
             ->each(function ($module) use ($name) {
             })
             // Create injectors
-            ->reduce(function ($injectors, $module) use ($options, $packageTypes) {
-                $injectors[$module] = $this->promptForConfigOption($module, $options, $packageTypes[$module]);
+            ->reduce(function ($injectors, $module) use ($options, $packageTypes, $extra) {
+                $injectors[$module] = $this->promptForConfigOption($module, $options, $packageTypes[$module], $extra);
                 return $injectors;
             }, new Collection([]))
             // Inject modules into configuration
@@ -407,12 +407,18 @@ class ComponentInstaller implements
      * @param string $name
      * @param Collection $options
      * @param int $packageType
+     * @param array $extra
      * @return Injector\InjectorInterface
      */
-    private function promptForConfigOption($name, Collection $options, $packageType)
+    private function promptForConfigOption($name, Collection $options, $packageType, array $extra)
     {
         if ($cachedInjector = $this->getCachedInjector($packageType)) {
             return $cachedInjector;
+        }
+
+        // If package is whitelisted, don't ask...
+        if (array_key_exists('component-whitelist', $extra) && in_array($name, $extra['component-whitelist'])) {
+            return $options[1]->getInjector();
         }
 
         // Default to first discovered option; index 0 is always "Do not inject"

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-component-installer for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-component-installer/blob/master/LICENSE.md New BSD License
  */
 
@@ -13,6 +13,7 @@ use Composer\Installer\InstallationManager;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackageInterface;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
@@ -40,6 +41,11 @@ class ComponentInstallerTest extends TestCase
     private $composer;
 
     /**
+     * @var RootPackageInterface
+     */
+    private $rootPackage;
+
+    /**
      * @var IOInterface|ObjectProphecy
      */
     private $io;
@@ -55,7 +61,11 @@ class ComponentInstallerTest extends TestCase
         $this->installer = new ComponentInstaller(vfsStream::url('project'));
 
         $this->composer = $this->prophesize(Composer::class);
+        $this->rootPackage = $this->prophesize(RootPackageInterface::class);
         $this->io = $this->prophesize(IOInterface::class);
+
+        $this->composer->getPackage()->willReturn($this->rootPackage->reveal());
+        $this->rootPackage->getExtra()->willReturn([]);
 
         $this->installer->activate(
             $this->composer->reveal(),
@@ -1172,7 +1182,7 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io
-            ->write('<info>Removing Some\Component from package some/component</info>')
+            ->write('<info>    Removing Some\Component from package some/component</info>')
             ->shouldBeCalled();
 
         $this->io
@@ -1214,10 +1224,10 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io
-            ->write('<info>Removing Some\Component from package some/component</info>')
+            ->write('<info>    Removing Some\Component from package some/component</info>')
             ->shouldBeCalled();
         $this->io
-            ->write('<info>Removing Other\Component from package some/component</info>')
+            ->write('<info>    Removing Other\Component from package some/component</info>')
             ->shouldBeCalled();
 
         $this->io
@@ -1671,7 +1681,7 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io
-            ->write('<info>Removing Some\Component from package some/component</info>')
+            ->write('<info>    Removing Some\Component from package some/component</info>')
             ->shouldBeCalled();
 
         // assertion


### PR DESCRIPTION
Add an option to read a list of whitelisted packages from the project composer file. Packages in that list are installed silently without the installation prompt. To prevent abuse, only a whitelist in the project composer file is allowed.

```json
    "extra": {
        "zf": {
            "component-whitelist": [
                "zendframework/zend-expressive-router",
                "zendframework/zend-expressive-fastroute",
                "zendframework/zend-expressive-twigrenderer",
                "zendframework/zend-expressive-helpers"
            ]
        }
    },
```

See zendframework/zend-expressive-skeleton#207
See zendframework/zend-expressive-skeleton#204

Closes #48