### PR TITLE
Convert questions to a string

### DIFF
--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -18,7 +18,6 @@ use DirectoryIterator;
 use Zend\ComponentInstaller\Injector\AbstractInjector;
 use Zend\ComponentInstaller\Injector\ConfigInjectorChain;
 use Zend\ComponentInstaller\Injector\InjectorInterface;
-use Zend\ComponentInstaller\Injector\NoopInjector;
 
 /**
  * If a package represents a component module, update the application configuration.

--- a/src/ComponentInstaller.php
+++ b/src/ComponentInstaller.php
@@ -449,7 +449,7 @@ class ComponentInstaller implements
         $ask[] = sprintf('  Make your selection (default is <comment>%d</comment>):', $default);
 
         while (true) {
-            $answer = $this->io->ask($ask, $default);
+            $answer = $this->io->ask(implode($ask), $default);
 
             if (is_numeric($answer) && isset($options[(int) $answer])) {
                 $injector = $options[(int) $answer]->getInjector();
@@ -474,7 +474,7 @@ class ComponentInstaller implements
         $ask = ["\n  <question>Remember this option for other packages of the same type? (Y/n)</question>"];
 
         while (true) {
-            $answer = strtolower($this->io->ask($ask, 'y'));
+            $answer = strtolower($this->io->ask(implode($ask), 'y'));
 
             switch ($answer) {
                 case 'y':

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -76,6 +76,38 @@ class ComponentInstallerTest extends TestCase
         $this->composer->getInstallationManager()->willReturn($this->installationManager->reveal());
     }
 
+    public static function assertPrompt($argument, $packageName = null)
+    {
+        if (! is_string($argument)) {
+            return false;
+        }
+
+        if (false !== strpos($argument, 'Remember this option for other packages of the same type?')) {
+            return true;
+        }
+
+        if (! $packageName) {
+            return false;
+        }
+
+        if (false === strpos(
+                $argument,
+                sprintf("Please select which config file you wish to inject '%s' into", $packageName)
+            )) {
+            return false;
+        }
+
+        if (false === strpos($argument, 'Do not inject')) {
+            return false;
+        }
+
+        if (false === strpos($argument, 'application.config.php')) {
+            return false;
+        }
+
+        return true;
+    }
+
     public function createApplicationConfig($contents = null)
     {
         $contents = $contents ?: '<' . "?php\nreturn [\n    'modules' => [\n    ]\n];";
@@ -141,37 +173,11 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-
-            if (false === strpos(
-                $argument[0],
-                "Please select which config file you wish to inject 'SomeComponent' into"
-            )) {
-                return false;
-            }
-
-            if (false === strpos($argument[1], 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument[2], 'application.config.php')) {
-                return false;
-            }
-
-            return true;
+            return ComponentInstallerTest::assertPrompt($argument, 'SomeComponent');
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-            if (false === strpos($argument[0], 'Remember')) {
-                return false;
-            }
-
-            return true;
+            return ComponentInstallerTest::assertPrompt($argument);
         }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
@@ -515,37 +521,11 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) use ($packageName) {
-            if (! is_array($argument)) {
-                return false;
-            }
-
-            if (false === strpos(
-                $argument[0],
-                sprintf("Please select which config file you wish to inject '%s' into", $packageName)
-            )) {
-                return false;
-            }
-
-            if (false === strpos($argument[1], 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument[2], 'application.config.php')) {
-                return false;
-            }
-
-            return true;
+            return ComponentInstallerTest::assertPrompt($argument, $packageName);
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-            if (false === strpos($argument[0], 'Remember')) {
-                return false;
-            }
-
-            return true;
+            return ComponentInstallerTest::assertPrompt($argument);
         }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) use ($packageName) {
@@ -637,37 +617,11 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-
-            if (false === strpos(
-                $argument[0],
-                "Please select which config file you wish to inject 'SomeModule' into"
-            )) {
-                return false;
-            }
-
-            if (false === strpos($argument[1], 'Do not inject')) {
-                return false;
-            }
-
-            if (false === strpos($argument[2], 'application.config.php')) {
-                return false;
-            }
-
-            return true;
+            return ComponentInstallerTest::assertPrompt($argument, 'SomeModule');
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
-                return false;
-            }
-            if (false === strpos($argument[0], 'Remember')) {
-                return false;
-            }
-
-            return true;
+            return ComponentInstallerTest::assertPrompt($argument);
         }), 'y')->willReturn('y');
 
         $this->io->write(Argument::that(function ($argument) {
@@ -827,22 +781,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -850,10 +804,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -891,22 +845,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -914,22 +868,22 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Other\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -938,10 +892,10 @@ CONTENT
 
         $io = $this->io;
         $askValidator = function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                     return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -990,22 +944,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1013,10 +967,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -1047,22 +1001,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Other\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1070,10 +1024,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -1109,22 +1063,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1132,10 +1086,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -1298,22 +1252,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Module' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1321,10 +1275,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -1366,22 +1320,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Module' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1389,22 +1343,22 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1412,10 +1366,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 
@@ -1462,22 +1416,22 @@ CONTENT
         $event->getOperation()->willReturn($operation->reveal());
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Module' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1485,22 +1439,22 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
 
             if (false === strpos(
-                $argument[0],
+                $argument,
                 "Please select which config file you wish to inject 'Some\Component' into"
             )) {
                 return false;
             }
 
-            if (false === strpos($argument[1], 'Do not inject')) {
+            if (false === strpos($argument, 'Do not inject')) {
                 return false;
             }
 
-            if (false === strpos($argument[2], 'application.config.php')) {
+            if (false === strpos($argument, 'application.config.php')) {
                 return false;
             }
 
@@ -1508,10 +1462,10 @@ CONTENT
         }), 1)->willReturn(1);
 
         $this->io->ask(Argument::that(function ($argument) {
-            if (! is_array($argument)) {
+            if (! is_string($argument)) {
                 return false;
             }
-            if (false === strpos($argument[0], 'Remember')) {
+            if (false === strpos($argument, 'Remember')) {
                 return false;
             }
 

--- a/test/ComponentInstallerTest.php
+++ b/test/ComponentInstallerTest.php
@@ -16,7 +16,6 @@ use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
-use org\bovigo\vfs\vfsStreamWrapper;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;


### PR DESCRIPTION
Since symfony/console 4 questions only accept a question string. Looking at its history, this was always the case and is wrong in the composer docblock.

see: https://github.com/symfony/console/blob/4.0/Question/Question.php#L37
see: https://github.com/composer/composer/blob/1.6/src/Composer/IO/IOInterface.php#L106
related: zendframework/zend-expressive-skeleton#244
related: zendframework/zend-expressive-skeleton#243