### PR TITLE
Fixed code snippets

### DIFF
--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -111,20 +111,21 @@ workflow, you will need:
 
 * A configuration provider class. This is a class with no constructor
   arguments defining an `__invoke()` method returning a configuration array.
-* An `extra.zf.config-provider` entry listing the configuration provider class
-  in your `composer.json`.
 
 ```php
 namespace Some\Component;
 
 class ConfigProvider
 {
-  public function __invoke()
-  {
-      return [ /* ... */ ];
-  }
+    public function __invoke()
+    {
+        return [ /* ... */ ];
+    }
 }
 ```
+
+* An `extra.zf.config-provider` entry listing the configuration provider class
+  in your `composer.json`.
 
 ```json
 "extra": {


### PR DESCRIPTION
Two different code snippets were placed into tabs.
Unfortunately indent code blocks are not working right now.

Before:

![image](https://user-images.githubusercontent.com/7423207/68027652-cfa75280-fcaa-11e9-9545-d4d8e72e125e.png)

After:

<img width="879" alt="image" src="https://user-images.githubusercontent.com/7423207/68027662-d766f700-fcaa-11e9-8857-27d0f05af488.png">

