### PR TITLE
Fixed link and name for: zf-development-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,7 +490,7 @@ tagged releases now make more sense, as plugins are installed via composer
   - to act as a Composer plugin.
   - to add awareness of additional configuration locations:
     - `modules.config.php` (Apigility)
-    - `development.config.php` (zend-development-mode)
+    - `development.config.php` (zf-development-mode)
     - `config.php` (Expressive with expressive-config-manager)
   - to discover and prompt for known configuration locations when installing a
     package.

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -54,7 +54,7 @@ the component:
 * `config/application.config.php` (vanilla ZF2 application)
 * `config/modules.config.php` ([Apigility](https://apigility.org) application)
 * `config/development.config.php.dist` and `config/development.config.php`
-  (applications using [zend-development-mode](https://github.com/zendframework/zend-development-mode))
+  (applications using [zf-development-mode](https://github.com/zfcampus/zf-development-mode))
 
 Components are added at the **top** of the application's list of modules.
 
@@ -96,7 +96,7 @@ the module:
 * `config/application.config.php` (vanilla ZF2 application)
 * `config/modules.config.php` ([Apigility](https://apigility.org) application)
 * `config/development.config.php.dist` and `config/development.config.php`
-  (applications using [zend-development-mode](https://github.com/zendframework/zend-development-mode))
+  (applications using [zf-development-mode](https://github.com/zfcampus/zf-development-mode))
 
 Modules are added at the **bottom** of the application's list of modules.
 


### PR DESCRIPTION
We would need to check all other places but somehow github search was not able to find even this one. I knew we fixed it in past somewhere else.